### PR TITLE
Fix Antag Spawns

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -3,7 +3,7 @@
 	round_description = "Some crewmembers are attempting to start a cult!"
 	extended_round_description = "There has been an infiltration by a fanatical group of death-cultists! They will use powers from beyond your comprehension to subvert you to their cause and ultimately please their gods through sacrificial summons and physical immolation! Try to survive!"
 	config_tag = "cult"
-	required_players = 12
-	required_enemies = 4
+	required_players = 10 //Originally 12, updated to match God Cult spawn value
+	required_enemies = 3 //Originally 4, updated to match Gold Cult spawn value
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_CULTIST)

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -6,7 +6,7 @@
 	name = "Heist"
 	config_tag = "heist"
 	required_players = 6
-	required_enemies = 3
+	required_enemies = 2 //Originally 3, updated for lowpop (Also, 3v3 heist? Why though)
 	round_description = "An unidentified bluespace signature has slipped into close sensor range and is approaching!"
 	extended_round_description = "The Company's majority control of phoron in Nyx has marked the \
 		station to be a highly valuable target for many competing organizations and individuals. Being a \

--- a/code/game/gamemodes/mixed/crossfire.dm
+++ b/code/game/gamemodes/mixed/crossfire.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Nothing can possibly go wrong with lots of people and lots of guns, right?"
 	config_tag = "crossfire"
 	required_players = 14
-	required_enemies = 6
+	required_enemies = 4 //Originally 6, updated for lowpop and to ensure the mode actually spawns people in
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_RAIDER, MODE_MERCENARY)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/uprising.dm
+++ b/code/game/gamemodes/mixed/uprising.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Cultists and revolutionaries spawn in this round."
 	config_tag = "uprising"
 	required_players = 14
-	required_enemies = 6
+	required_enemies = 4 //Originally 6, updated for lowpop and to ensure they actually spawn in
 	end_on_antag_death = FALSE
 	auto_recall_shuttle = FALSE
 	shuttle_delay = 2

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -13,7 +13,7 @@ var/list/nuke_disks = list()
 		attempts of robbery, fraud and other malicious actions."
 	config_tag = "mercenary"
 	required_players = 12
-	required_enemies = 6
+	required_enemies = 2 //Originally 6, changed for lowpop (also the max number of mercs is 5, who thought 6 minimum would work...?)
 	end_on_antag_death = FALSE
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station
 	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

A quick PR to edit antag spawns. Mercenary was set to 6 required mercenaries to start the game, which is above the limit of 5, causing it to always fail when voted for. A few other gamemodes have had their required antags reduced slightly to make it more likely that it'll go through when voted for.

## Changelog:
🆑
Updated required_enemies in nuclear.dm to 2 instead of 6
Updated required_enemies in heist.dm to 2 instead of 3
Updated required_enemies in crossfire.dm (Mercs and Heist) to 4 instead of 6
Updated required_enemies in uprising.dm (Mercs and Revs) to 4 instead of 6
Updated required_enemies in cult.dm to 3 instead of 4
Updated required_players in cult.dm to 10 instead of 12
/🆑
