### PR TITLE
Unathi regen slower with bigger wounds

### DIFF
--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -4,6 +4,8 @@
 	var/fire_mult = 1
 	var/tox_mult = 1
 	var/oxy_mult = 0
+	var/brute_mal = 0
+	var/organ_mal = 0
 
 /obj/aura/regenerating/life_tick()
 	user.adjustBruteLoss(-brute_mult)
@@ -17,7 +19,7 @@
 	var/regen_message = "<span class='warning'>Your body throbs as you feel your ORGAN regenerate.</span>"
 	var/grow_chance = 0
 	var/grow_threshold = 0
-	var/ignore_tag//organ tag to ignore
+	var/ignore_tag //organ tag to ignore
 	var/last_nutrition_warning = 0
 	var/innate_heal = TRUE // Whether the aura is on, basically.
 
@@ -37,7 +39,7 @@
 		return 0
 
 	if(brute_mult && H.getBruteLoss())
-		H.adjustBruteLoss(-brute_mult * config.organ_regeneration_multiplier)
+		H.adjustBruteLoss((-brute_mult + brute_mal)* config.organ_regeneration_multiplier)
 		H.adjust_nutrition(-nutrition_damage_mult)
 	if(fire_mult && H.getFireLoss())
 		H.adjustFireLoss(-fire_mult * config.organ_regeneration_multiplier)
@@ -68,8 +70,8 @@
 			if(istype(regen_organ))
 				if(regen_organ.damage > 0 && !(regen_organ.status & ORGAN_DEAD))
 					if (H.nutrition >= organ_mult)
-						regen_organ.damage = max(regen_organ.damage - organ_mult, 0)
-						H.adjust_nutrition(-organ_mult)
+						regen_organ.damage = max(regen_organ.damage - (organ_mult + organ_mal), 0)
+						H.adjust_nutrition(-organ_mult + organ_mal)
 						if(prob(5))
 							to_chat(H, replacetext(regen_message,"ORGAN", regen_organ.name))
 					else
@@ -150,6 +152,23 @@
 		H.apply_damage(5, TOX)
 		H.adjust_nutrition(3)
 		return 1
+
+	if(H.getBruteLoss() >= 30 && !(organ_mal >= 1))
+		brute_mal = 0.3
+		organ_mal = 1
+	else if(H.getBruteLoss() >= 60 && !(organ_mal >= 2))
+		brute_mal = 0.5
+		organ_mal = 2
+	else if(H.getBruteLoss() >= 100)
+		brute_mal = 1
+		organ_mal = 3
+
+	if(H.getFireLoss() >= 30 && !(organ_mal >= 1))
+		organ_mal = 1
+	else if(H.getFireLoss() >= 60 && !(organ_mal >= 2))
+		organ_mal = 2
+	else if(H.getFireLoss() >= 100)
+		organ_mal = 3
 	return ..()
 
 /obj/aura/regenerating/human/unathi/can_regenerate_organs()


### PR DESCRIPTION
Unathi regen wounds slower as damage on them increases

- 30+ brute = 0.3 malice to brute regen and 1 to organ regen
- 60+ brute = 0.5 malice to brute regen and 2 to organ regen
- 100+ brute = 1 malice to brute regen and 3 to organ regen

- 30+ fire = 1 to organ regen
- 60+ fire = 2 to organ regen
- 100+ fire = 3 to organ regen