### PR TITLE
Adds Nanotrasen, changes EC ranks

### DIFF
--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -140,8 +140,7 @@
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer/marine
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/e2,
-		/datum/mil_rank/fleet/e2_exp,
+		/datum/mil_rank/fleet/e2, 
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/marine_corps/e2,
 		/datum/mil_rank/marine_corps/e3
@@ -152,7 +151,6 @@
 /datum/job/pathfinder
 	allowed_branches = list(/datum/mil_branch/fleet)
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/e7_exp,
 		/datum/mil_rank/fleet/o1,
 		/datum/mil_rank/fleet/o2
 	)
@@ -160,25 +158,25 @@
 /datum/job/nt_pilot
 	allowed_branches = list(
 		/datum/mil_branch/civilian,
-		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/exploration/pilot
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/exploration/pilot,
+		/datum/mil_branch/nanotrasen
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/nt_pilot,
-		/datum/mil_rank/fleet/e5_exp,
-		/datum/mil_rank/fleet/e7_exp,
+		/datum/mil_rank/nanotrasen/e7_exp,
 		/datum/mil_rank/fleet/w1,
 		/datum/mil_rank/fleet/w2
 	)
 
 /datum/job/explorer
-	allowed_branches = list(/datum/mil_branch/fleet)
+	allowed_branches = list(/datum/mil_branch/nanotrasen)
 
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/e2_exp,
-		/datum/mil_rank/fleet/e3_exp,
-		/datum/mil_rank/fleet/e5_exp
+		/datum/mil_rank/nanotrasen/e2_exp,
+		/datum/mil_rank/nanotrasen/e3_exp,
+		/datum/mil_rank/nanotrasen/e5_exp
 	)
-	min_skill = list(SKILL_EVA = SKILL_BASIC, SKILL_SCIENCE = SKILL_BASIC) // To make up NTEF not having sci skill by default.
+	min_skill = list(SKILL_EVA = SKILL_BASIC, SKILL_SCIENCE = SKILL_BASIC) // To make up NT not having sci skill by default.
 /***/
 
 // Medical
@@ -222,7 +220,6 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e2,
-		/datum/mil_rank/fleet/e2_exp,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/marine_corps/e2,
 		/datum/mil_rank/marine_corps/e3
@@ -249,33 +246,30 @@
 		/datum/mil_branch/fleet
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/o3
+		/datum/mil_rank/fleet/o1,
+		/datum/mil_rank/fleet/o2
 	)
 
 /datum/job/scientist
 	allowed_branches = list(
-		/datum/mil_branch/fleet,
+		/datum/mil_branch/nanotrasen,
 		/datum/mil_branch/civilian,
 		/datum/mil_branch/solgov
 	)
-	allowed_ranks = list(,
-		/datum/mil_rank/fleet/e7_exp,
-		/datum/mil_rank/fleet/o1,
-		/datum/mil_rank/fleet/o2,
+	allowed_ranks = list(
+		/datum/mil_rank/nanotrasen/nt_emp,
 		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/scientist,
 		/datum/mil_rank/sol/scientist = /decl/hierarchy/outfit/job/torch/passenger/research/scientist/solgov
 	)
 
 /datum/job/scientist_assistant
 	allowed_branches = list(
-		/datum/mil_branch/fleet,
+		/datum/mil_branch/nanotrasen,
 		/datum/mil_branch/civilian,
 		/datum/mil_branch/solgov
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/e2_exp,
-		/datum/mil_rank/fleet/e3_exp,
-		/datum/mil_rank/fleet/e5_exp,
+		/datum/mil_rank/nanotrasen/nt_int,
 		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/assist,
 		/datum/mil_rank/sol/scientist = /decl/hierarchy/outfit/job/torch/passenger/research/assist/solgov
 	)
@@ -370,7 +364,6 @@
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/fleet/e2,
-		/datum/mil_rank/fleet/e2_exp,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
@@ -441,7 +434,6 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e2,
-		/datum/mil_rank/fleet/e2_exp,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -1,5 +1,5 @@
 // Branch-specific defines
-#define UNRESTRICTED /datum/mil_branch/civilian, /datum/mil_branch/fleet
+#define UNRESTRICTED /datum/mil_branch/civilian, /datum/mil_branch/fleet, /datum/mil_branch/nanotrasen
 #define SEMIRESTRICTED /datum/mil_branch/marine_corps, /datum/mil_branch/private_security
 
 // Rank-specific defines
@@ -33,15 +33,11 @@
 #define NTEF_ENLISTED_ONLY /datum/mil_branch/fleet = list(\
 	/datum/mil_rank/fleet/e1, \
 	/datum/mil_rank/fleet/e2, \
-	/datum/mil_rank/fleet/e2_exp, \
 	/datum/mil_rank/fleet/e3, \
-	/datum/mil_rank/fleet/e3_exp, \
 	/datum/mil_rank/fleet/e4, \
 	/datum/mil_rank/fleet/e5, \
-	/datum/mil_rank/fleet/e5_exp, \
 	/datum/mil_rank/fleet/e6, \
 	/datum/mil_rank/fleet/e7, \
-	/datum/mil_rank/fleet/e7_exp, \
 	/datum/mil_rank/fleet/e8, \
 	/datum/mil_rank/fleet/e9, \
 	/datum/mil_rank/fleet/e9_alt1, \
@@ -50,6 +46,16 @@
 	/datum/mil_rank/sol/gov, \
 	/datum/mil_rank/sol/scientist, \
 	)
+
+#define NT_EC_CIV /datum/mil_branch/nanotrasen = list(	rank_types = list(\
+		/datum/mil_rank/nanotrasen/nt_int,\
+		/datum/mil_rank/nanotrasen/nt_emp,\
+		/datum/mil_rank/nanotrasen/e1_exp,\
+		/datum/mil_rank/nanotrasen/e2_exp,\
+		/datum/mil_rank/nanotrasen/e3_exp,\
+		/datum/mil_rank/nanotrasen/e5_exp,\
+		/datum/mil_rank/nanotrasen/e7_exp \
+		)
 
 /datum/map/torch
 	branch_types = list(
@@ -61,7 +67,8 @@
 		/datum/mil_branch/private_security,
 		/datum/mil_branch/army,
 		/datum/mil_branch/alien,
-		/datum/mil_branch/skrell_fleet
+		/datum/mil_branch/skrell_fleet,
+		/datum/mil_branch/nanotrasen
 	)
 
 	spawn_branch_types = list(
@@ -71,7 +78,8 @@
 		/datum/mil_branch/solgov,
 		/datum/mil_branch/private_security,
 		/datum/mil_branch/alien,
-		/datum/mil_branch/skrell_fleet
+		/datum/mil_branch/skrell_fleet,
+		/datum/mil_branch/nanotrasen
 	)
 
 	species_to_branch_blacklist = list(
@@ -84,22 +92,23 @@
 			/datum/mil_branch/civilian,
 			/datum/mil_branch/private_security,
 			/datum/mil_branch/solgov,
-			/datum/mil_branch/skrell_fleet
+			/datum/mil_branch/skrell_fleet,
+			/datum/mil_branch/nanotrasen
 		)
 	)
 
 	species_to_branch_whitelist = list(
-		/datum/species/diona		= list(UNRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/private_security),
+		/datum/species/diona		= list(UNRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/private_security, /datum/mil_branch/nanotrasen),
 		/datum/species/nabber		= list(/datum/mil_branch/civilian),
-		/datum/species/skrell		= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/skrell_fleet),
-		/datum/species/unathi		= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov),
-		/datum/species/unathi/yeosa	= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov),
-		/datum/species/adherent		= list(/datum/mil_branch/civilian, /datum/mil_branch/solgov),
-		/datum/species/custom		= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov),
-		/datum/species/humanathi	= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov),
-		/datum/species/tajaran		= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov),
- 		/datum/species/shapeshifter/promethean	= list(UNRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/private_security),
-		/datum/species/plasmasans	= list(/datum/mil_branch/civilian, /datum/mil_branch/solgov),
+		/datum/species/skrell		= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/skrell_fleet, /datum/mil_branch/nanotrasen),
+		/datum/species/unathi		= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/nanotrasen),
+		/datum/species/unathi/yeosa	= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/nanotrasen),
+		/datum/species/adherent		= list(/datum/mil_branch/civilian, /datum/mil_branch/solgov, /datum/mil_branch/nanotrasen),
+		/datum/species/custom		= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/nanotrasen),
+		/datum/species/humanathi	= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/nanotrasen),
+		/datum/species/tajaran		= list(UNRESTRICTED, SEMIRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/nanotrasen),
+ 		/datum/species/shapeshifter/promethean	= list(UNRESTRICTED, /datum/mil_branch/solgov, /datum/mil_branch/private_security, /datum/mil_branch/nanotrasen),
+		/datum/species/plasmasans	= list(/datum/mil_branch/civilian, /datum/mil_branch/solgov, /datum/mil_branch/nanotrasen),
 		/datum/species/vox			= list(/datum/mil_branch/alien),
 		/datum/species/vox/armalis	= list(/datum/mil_branch/alien)
 	)
@@ -118,17 +127,12 @@
 
 	rank_types = list(
 		/datum/mil_rank/fleet/e1,
-		/datum/mil_rank/fleet/e1_exp,
 		/datum/mil_rank/fleet/e2,
-		/datum/mil_rank/fleet/e2_exp,
 		/datum/mil_rank/fleet/e3,
-		/datum/mil_rank/fleet/e3_exp,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
-		/datum/mil_rank/fleet/e5_exp,
 		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/fleet/e7,
-		/datum/mil_rank/fleet/e7_exp,
 		/datum/mil_rank/fleet/e8,
 		/datum/mil_rank/fleet/e9,
 		/datum/mil_rank/fleet/e9_alt1,
@@ -155,15 +159,11 @@
 
 	spawn_rank_types = list(
 		/datum/mil_rank/fleet/e2,
-		/datum/mil_rank/fleet/e2_exp,
 		/datum/mil_rank/fleet/e3,
-		/datum/mil_rank/fleet/e3_exp,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
-		/datum/mil_rank/fleet/e5_exp,
 		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/fleet/e7,
-		/datum/mil_rank/fleet/e7_exp,
 		/datum/mil_rank/fleet/e8,
 		/datum/mil_rank/fleet/e9,
 		/datum/mil_rank/fleet/e9_alt1,
@@ -258,13 +258,6 @@
 	sort_order = 1
 	pow_cat = 1
 
-/datum/mil_rank/fleet/e1_exp
-	name = "Recruit Explorer"
-	name_short = "RXPL"
-	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted)
-	sort_order = 1
-	pow_cat = 1
-
 /datum/mil_rank/fleet/e2
 	name = "Crewman Apprentice"
 	name_short = "CA"
@@ -272,24 +265,10 @@
 	sort_order = 2
 	pow_cat = 1
 
-/datum/mil_rank/fleet/e2_exp
-	name = "Junior Explorer"
-	name_short = "JXPL"
-	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e2, /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer)
-	sort_order = 2
-	pow_cat = 1
-
 /datum/mil_rank/fleet/e3
 	name = "Crewman"
 	name_short = "CN"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e3, /obj/item/clothing/accessory/solgov/specialty/enlisted)
-	sort_order = 3
-	pow_cat = 1
-
-/datum/mil_rank/fleet/e3_exp
-	name = "Explorer"
-	name_short = "XPL"
-	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e3, /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer)
 	sort_order = 3
 	pow_cat = 1
 
@@ -307,13 +286,6 @@
 	sort_order = 5
 	pow_cat = 2
 
-/datum/mil_rank/fleet/e5_exp
-	name = "Senior Explorer"
-	name_short = "SXPL"
-	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e5, /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer)
-	sort_order = 5
-	pow_cat = 2
-
 /datum/mil_rank/fleet/e6
 	name = "Petty Officer First Class"
 	name_short = "PO1"
@@ -325,13 +297,6 @@
 	name = "Chief Petty Officer"
 	name_short = "CPO"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e7, /obj/item/clothing/accessory/solgov/specialty/enlisted)
-	sort_order = 7
-	pow_cat = 2
-
-/datum/mil_rank/fleet/e7_exp
-	name = "Chief Explorer"
-	name_short = "CXPL"
-	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e7, /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer)
 	sort_order = 7
 	pow_cat = 2
 
@@ -724,6 +689,95 @@
 	pow_cat = 3
 /*****/
 
+// Nanotrasen Civilian Branch (Serves as a replacment for EC)
+/datum/mil_branch/nanotrasen
+	name = "Nanotrasen"
+	name_short = "NT"
+	email_domain = "nanotrasen.dagon.nt"
+
+	rank_types = list(
+		/datum/mil_rank/nanotrasen/nt_int,
+		/datum/mil_rank/nanotrasen/nt_emp,
+		/datum/mil_rank/nanotrasen/e1_exp,
+		/datum/mil_rank/nanotrasen/e2_exp,
+		/datum/mil_rank/nanotrasen/e3_exp,
+		/datum/mil_rank/nanotrasen/e5_exp,
+		/datum/mil_rank/nanotrasen/e7_exp
+	)
+	spawn_rank_types = list(
+		/datum/mil_rank/nanotrasen/nt_int,
+		/datum/mil_rank/nanotrasen/nt_emp,
+		/datum/mil_rank/nanotrasen/e2_exp,
+		/datum/mil_rank/nanotrasen/e3_exp,
+		/datum/mil_rank/nanotrasen/e5_exp,
+		/datum/mil_rank/nanotrasen/e7_exp
+	)
+//Civilian part of Nanotrasen
+
+
+//Nanotrasen Intern (Field Assistant/Lab Assistant)
+/datum/mil_rank/nanotrasen/nt_int
+	name = "Nanotrasen Intern"
+	name_short = "NTIT"
+	sort_order = 1
+	pow_cat = 3
+
+//Nanotrasen Employee (Scientist/Researcher)
+
+/datum/mil_rank/nanotrasen/nt_emp
+	name = "Nanotrasen Employee"
+	name_short = "NTEM"
+	sort_order = 2
+	pow_cat = 3
+
+//EC part of Nanotrasen
+
+//Nanotrasen RXPL (Not in use)
+
+/datum/mil_rank/nanotrasen/e1_exp
+	name = "Recruit Explorer"
+	name_short = "NTRE"
+	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted)
+	sort_order = 1
+	pow_cat = 3
+
+//Nanotrasen JXPL (Explorer)
+
+/datum/mil_rank/nanotrasen/e2_exp
+	name = "Nanotrasen Junior Explorer"
+	name_short = "NTJE"
+	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e2, /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer)
+	sort_order = 2
+	pow_cat = 3
+
+//Nanotrasen XPL (Explorer)
+
+/datum/mil_rank/nanotrasen/e3_exp
+	name = "Nanotrasen Explorer"
+	name_short = "NTEX"
+	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e3, /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer)
+	sort_order = 3
+	pow_cat = 3
+
+//Nanotrasen SXPL (Explorer)
+
+/datum/mil_rank/nanotrasen/e5_exp
+	name = "Nanotrasen Senior Explorer"
+	name_short = "NTSE"
+	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e5, /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer)
+	sort_order = 5
+	pow_cat = 3
+
+//Nanotrasen CXPL (Pilot)
+
+/datum/mil_rank/nanotrasen/e7_exp
+	name = "Nanotrasen Chief Explorer"
+	name_short = "NTCE"
+	accessory = list(/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e7, /obj/item/clothing/accessory/solgov/specialty/enlisted/explorer)
+	sort_order = 7
+	pow_cat = 3
+
+//
 // Ends of defines
 #undef UNRESTRICTED
 #undef SEMIRESTRICTED


### PR DESCRIPTION
Adds new branch to the Dagon lineup, Nanotrasen
Contains all EC ranks and also new ranks for science

*Moves every EC rank from NTEF to NT
*Removes EC ranking from every other department other than science and exploration
*Senior Researcher moved to O1 and O2 from O2-O3 (Subordinate shouldnt be same rank as their superior)
*Pathfinder got their enlisted rank removed (He is officer, doesnt make sense for him to have enlisted ranking)
*Researcher and Research assistant have gotten Nanotrasen Employee and Intern rank respectivly
*NTEF only now contains only now contains non EC ranks