### PR TITLE
Add resist and CTRL/ALT+WASD hotkeys

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -50,7 +50,31 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+South"
 		command = "southface"
+	elem
+		name = "ALT+A"
+		command = "westfaceperm"
 	elem 
+		name = "CTRL+A"
+		command = "westface"
+	elem 
+		name = "ALT+W"
+		command = "northfaceperm"
+	elem 
+		name = "CTRL+W"
+		command = "northface"
+	elem 
+		name = "ALT+D"
+		command = "eastfaceperm"
+	elem 
+		name = "CTRL+D"
+		command = "eastface"
+	elem 
+		name = "ALT+S"
+		command = "southfaceperm"
+	elem 
+		name = "CTRL+S"
+		command = "southface"
+	elem
 		name = "South+REP"
 		command = ".movedown"
 	elem 
@@ -161,6 +185,9 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+Z"
 		command = "Activate-Held-Object"
+	elem
+		name = "B"
+		command = "resist" 
 	elem 
 		name = "Numpad1"
 		command = "body-r-leg"
@@ -453,6 +480,30 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+South"
 		command = "southface"
+	elem
+		name = "ALT+A"
+		command = "westfaceperm"
+	elem 
+		name = "CTRL+A"
+		command = "westface"
+	elem 
+		name = "ALT+W"
+		command = "northfaceperm"
+	elem 
+		name = "CTRL+W"
+		command = "northface"
+	elem 
+		name = "ALT+D"
+		command = "eastfaceperm"
+	elem 
+		name = "CTRL+D"
+		command = "eastface"
+	elem 
+		name = "ALT+S"
+		command = "southfaceperm"
+	elem 
+		name = "CTRL+S"
+		command = "southface"
 	elem 
 		name = "South+REP"
 		command = ".movedown"
@@ -519,6 +570,9 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+G"
 		command = "a-intent right"
+	elem
+		name = "B"
+		command = "resist" 
 	elem 
 		name = "H"
 		command = "holster"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

B is a hotkey on some of other servers and we have CTRL/ALT+↑↓→← that allows you to turn around/fix your face direction, so why not to add them here?
Those hotkeys were only added to hotkey mode.