### PR TITLE
Adds a bunch of emergency shutters to deck 4 and deck 5 maintenance.

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -4134,6 +4134,7 @@
 "hi" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "hj" = (
@@ -4310,7 +4311,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/random/obstruction,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/fifthdeck/aftstarboard)
 "hE" = (
@@ -10600,6 +10601,7 @@
 "sk" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
 "sl" = (
@@ -16191,6 +16193,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/security)
+"LJ" = (
+/obj/random/obstruction,
+/turf/simulated/floor/plating,
+/area/vacant/bar)
 "LL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -16451,6 +16457,10 @@
 /obj/item/weapon/stool/bar,
 /turf/simulated/floor/wood/walnut,
 /area/vacant/bar)
+"MI" = (
+/obj/random/obstruction,
+/turf/simulated/floor/wood/walnut,
+/area/vacant/bar)
 "MN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -16700,9 +16710,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/aftstarboard)
 "NL" = (
-/obj/random/obstruction,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/vacant/bar)
+/area/maintenance/fifthdeck/aftstarboard)
 "NP" = (
 /obj/structure/table/rack{
 	dir = 8
@@ -19156,14 +19167,15 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
 "YH" = (
-/obj/random/obstruction,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/vacant/bar)
+/area/maintenance/fifthdeck/aftstarboard)
 "YJ" = (
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/phoron)
@@ -41233,7 +41245,7 @@ aa
 Xi
 QL
 yI
-Ne
+MI
 Lj
 zL
 fz
@@ -41638,7 +41650,7 @@ Xi
 QL
 TC
 HE
-yI
+LJ
 XI
 XI
 aD

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -970,6 +970,7 @@
 /area/hallway/primary/fourthdeck/fore)
 "cw" = (
 /obj/random/obstruction,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "cx" = (
@@ -1069,7 +1070,8 @@
 /turf/simulated/floor/tiled/white,
 /area/maintenance/aux_med)
 "cG" = (
-/obj/random/obstruction,
+/obj/machinery/door/firedoor,
+/obj/structure/curtain/black,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
 "cH" = (
@@ -1228,11 +1230,8 @@
 /turf/simulated/floor/tiled/white,
 /area/maintenance/aux_med)
 "cY" = (
-/obj/structure/catwalk,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
+/obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "cZ" = (
@@ -1711,6 +1710,7 @@
 "dU" = (
 /obj/structure/ladder,
 /obj/structure/catwalk,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/fourthdeck/forestarboard)
 "dV" = (
@@ -1994,6 +1994,7 @@
 "eq" = (
 /obj/structure/ladder,
 /obj/structure/catwalk,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/port)
 "er" = (
@@ -2168,6 +2169,7 @@
 	dir = 10;
 	icon_state = "intact"
 	},
+/obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "eF" = (
@@ -3670,6 +3672,18 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fourthdeck/aft)
+"iH" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/aft)
 "iM" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -5147,6 +5161,19 @@
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod2/station)
+"nF" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/foreport)
 "nH" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -6956,6 +6983,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"to" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/foreport)
 "tp" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -8793,6 +8832,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"yS" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/foreport)
 "ze" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -9453,9 +9498,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
+"BT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/foreport)
 "Ca" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ladder/up,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/foreport)
 "Cb" = (
@@ -12196,6 +12253,19 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
+"MQ" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/starboard)
 "MR" = (
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/fourthdeck/center)
@@ -13864,11 +13934,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/catwalk,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "RJ" = (
@@ -15128,13 +15195,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/forestarboard)
 "UV" = (
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1";
-	tag = "icon-railing0 (EAST)"
-	},
-/obj/structure/railing/mapped,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/catwalk,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "UY" = (
@@ -16530,7 +16593,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
 "YV" = (
-/obj/machinery/computer/modular/preset/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/power/apc{
 	dir = 8;
@@ -16540,6 +16602,10 @@
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/machinery/computer/modular/preset/engineering{
+	dir = 4;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/starboard)
@@ -31823,8 +31889,8 @@ yh
 MD
 TE
 OX
-Db
-QV
+nF
+BT
 Dc
 Dc
 Dc
@@ -32638,7 +32704,7 @@ OM
 Gl
 Gl
 Gl
-Gl
+to
 OM
 IL
 DT
@@ -32840,7 +32906,7 @@ Vd
 Vd
 Vd
 Vd
-Vd
+yS
 Vd
 XB
 Or
@@ -37255,7 +37321,7 @@ cf
 cO
 cO
 ea
-by
+MQ
 by
 SX
 rF
@@ -42520,7 +42586,7 @@ mT
 od
 Mw
 RE
-OK
+iH
 tp
 sW
 Nx


### PR DESCRIPTION
Added a bunch of emergency shutters to deck 4 and deck 5 maintenance to assist with one explosion venting half the ship.

Has been a long time coming. Notably, adds emergency shutters on the top/bottom of ladders and adds shutters to cut those areas off so they can't vent half the ship.

Will do more of this sort of thing soon after next round of PRs, for other decks.