### PR TITLE
Monarch Serpentids

### DIFF
--- a/code/modules/ascent/ascent_rigs.dm
+++ b/code/modules/ascent/ascent_rigs.dm
@@ -213,6 +213,21 @@
 		list("tramadol",            "tramadol",            /datum/reagent/tramadol,      80),
 		list("crystal brothime",    "crystal brothime",    /datum/reagent/crystaltram,   80)
 	)
+//Serpentid version of chemical injector
+/obj/item/rig_module/chem_dispenser/mantid/serpentid
+	name = "serpentid chemical injector"
+	desc = "A compact chemical dispenser of mantid design."
+	interface_name = "serpentid chemical injector"
+	interface_desc = "A compact chemical dispenser of mantid design."
+	icon = 'icons/obj/ascent.dmi'
+	icon_state = "injector"
+	charges = list(
+		list("inaprovaline", "inaprovaline", /datum/reagent/inaprovaline, 20),
+		list("dexalin plus", "dexalin plus", /datum/reagent/dexalinp,       20),
+		list("spaceacillin", "spaceacillin", /datum/reagent/spaceacillin,  20),
+		list("tramadol",   "tramadol",    /datum/reagent/tramadol,      20),
+		list("glucose",    "glucose",   /datum/reagent/nutriment/glucose,   20)
+	)
 
 // Rig definitions.
 /obj/item/weapon/rig/mantid/gyne
@@ -244,7 +259,7 @@
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/batterer
 	)
-
+//Normal rig for her guards
 /obj/item/weapon/rig/mantid/nabber
 	name = "serpentid utility exosuit"
 	icon_override = 'icons/mob/species/nabber/onmob_back_gas.dmi'
@@ -255,7 +270,8 @@
 
 /obj/item/clothing/suit/space/rig/mantid/serpentid
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET
-
+	
+//Queen Rig
 /obj/item/weapon/rig/mantid/nabber/queen
 	name = "small support exosuit"
 	mantid_caste = SPECIES_MONARCH_QUEEN
@@ -263,7 +279,7 @@
 		/obj/item/rig_module/vision/thermal,
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/electrowarfare_suite,
-		/obj/item/rig_module/chem_dispenser/mantid,
+		/obj/item/rig_module/chem_dispenser/mantid/serpentid,
 		/obj/item/rig_module/device/nanoblade,
 		/obj/item/rig_module/mounted/flechette_rifle,
 		/obj/item/rig_module/mounted/particle_rifle,

--- a/code/modules/species/mantid/mantid.dm
+++ b/code/modules/species/mantid/mantid.dm
@@ -234,4 +234,5 @@
 
 /datum/species/nabber/monarch/queen
 	name = SPECIES_MONARCH_QUEEN
+	spawn_flags = SPECIES_IS_WHITELISTED
 	name_plural = "Monarch Serpentid Queens"

--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -1398,8 +1398,8 @@
 /area/ship/ascent/subdeck_atmos)
 "da" = (
 /obj/machinery/atmospherics/unary/freezer{
-	icon_state = "freezer";
-	dir = 1
+	dir = 1;
+	icon_state = "freezer"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/subdeck_hospital)
@@ -1624,8 +1624,8 @@
 "dy" = (
 /obj/structure/bed/chair/padded/purple/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/subdeck_atmos)
@@ -1698,6 +1698,7 @@
 "dH" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/storage/box/ascentimplants,
+/obj/item/weapon/storage/box/ascentimplants,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/subdeck_armory)
 "dI" = (
@@ -1762,6 +1763,8 @@
 /area/ship/ascent/subdeck_armory)
 "dN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on/ascent,
+/obj/structure/table/rack/dark,
+/obj/item/weapon/rig/mantid/nabber/queen,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/subdeck_armory)
 "dO" = (
@@ -2433,6 +2436,61 @@
 /obj/structure/bed/chair/padded/purple/ascent,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/subdeck_gyne_quarters)
+"po" = (
+/obj/structure/table/rack/dark,
+/obj/item/weapon/rig/mantid/nabber,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/subdeck_armory)
+"uP" = (
+/obj/structure/table/rack/dark,
+/obj/item/weapon/tank/mantid/reactor,
+/obj/item/clothing/mask/gas/ascent,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/subdeck_armory)
+"ys" = (
+/obj/structure/table/rack/dark,
+/obj/item/clothing/mask/gas/ascent,
+/obj/item/weapon/tank/mantid/reactor,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/subdeck_armory)
+"CN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/ascent,
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship/queen,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/subdeck_center)
+"Iw" = (
+/obj/machinery/light/ascent,
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship/adjunct,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/subdeck_center)
+"Lk" = (
+/obj/structure/table/rack/dark,
+/obj/item/ascentbox,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/subdeck_armory)
+"PX" = (
+/obj/structure/table/rack/dark,
+/obj/item/weapon/storage/box/ascentimplants,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/subdeck_armory)
+"TR" = (
+/obj/machinery/light/ascent{
+	dir = 1
+	},
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship/adjunct,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/subdeck_center)
 
 (1,1,1) = {"
 aa
@@ -8111,9 +8169,9 @@ cq
 bu
 bu
 al
-aq
+TR
 aK
-bC
+Iw
 al
 bt
 bt
@@ -8234,7 +8292,7 @@ cD
 bu
 ak
 ak
-aK
+CN
 ak
 ak
 bt
@@ -10426,15 +10484,15 @@ ai
 ai
 by
 bK
-ch
-ch
+Lk
+uP
 dI
-ch
+po
 dL
-ch
+po
 dI
-ch
-ch
+uP
+Lk
 ft
 by
 ai
@@ -10671,8 +10729,8 @@ ai
 by
 bK
 ch
-ch
-ch
+PX
+ys
 dN
 dV
 fn

--- a/maps/away/ascent/ascent-2.dmm
+++ b/maps/away/ascent/ascent-2.dmm
@@ -40,8 +40,8 @@
 /area/ship/ascent/wing_starboard)
 "al" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/wall/r_wall/ascent,
 /area/ship/ascent/shuttle_starboard)
@@ -3181,8 +3181,8 @@
 	pixel_y = 32
 	},
 /obj/structure/railing/mapped{
-	icon_state = "railing0-1";
-	dir = 4
+	dir = 4;
+	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_starboard_prow)
@@ -4543,8 +4543,8 @@
 /area/ship/ascent/shuttle_starboard)
 "vY" = (
 /obj/structure/railing/mapped{
-	icon_state = "railing0-1";
-	dir = 4
+	dir = 4;
+	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
@@ -4721,8 +4721,8 @@
 	name = "heavy duty box"
 	},
 /obj/structure/railing/mapped{
-	icon_state = "railing0-1";
-	dir = 8
+	dir = 8;
+	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
@@ -4822,8 +4822,8 @@
 "IQ" = (
 /obj/effect/wallframe_spawn/reinforced_phoron/hull,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
@@ -5027,8 +5027,8 @@
 /area/ship/ascent/fore_starboard_jut)
 "QT" = (
 /obj/structure/hygiene/shower/ascent{
-	icon_state = "shower";
-	dir = 1
+	dir = 1;
+	icon_state = "shower"
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_hallway)
@@ -5080,8 +5080,8 @@
 /area/ship/ascent/shuttle_starboard)
 "TO" = (
 /obj/structure/hygiene/shower/ascent{
-	icon_state = "shower";
-	dir = 8
+	dir = 8;
+	icon_state = "shower"
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_hallway)
@@ -5131,8 +5131,8 @@
 /area/ship/ascent/shuttle_starboard)
 "Vx" = (
 /obj/structure/railing/mapped{
-	icon_state = "railing0-1";
-	dir = 4
+	dir = 4;
+	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_starboard_prow)

--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -14,8 +14,8 @@
 		/datum/job/submap/ascent/alate,
 		/datum/job/submap/ascent/drone,
 		//datum/job/submap/ascent/control_mind,
-		//datum/job/submap/ascent/msq,
-		//datum/job/submap/ascent/msw,
+		/datum/job/submap/ascent/msq,
+		/datum/job/submap/ascent/msw,
 	)
 	call_webhook = WEBHOOK_SUBMAP_LOADED_ASCENT
 
@@ -173,10 +173,10 @@
 	set_species_on_join = /mob/living/silicon/robot/flying/ascent
 	requires_supervisor = "Ascent Gyne"
 
-/*
 /datum/job/submap/ascent/msw
 	title = "Serpentid Adjunct"
 	supervisors = "your Queen"
+	requires_supervisor = "Serpentid Queen"
 	total_positions = 2
 	info = "You are a Monarch Serpentid Worker serving as an attendant to your Queen on this vessel. Serve her however she requires."
 	set_species_on_join = SPECIES_MONARCH_WORKER
@@ -191,6 +191,7 @@
 /datum/job/submap/ascent/msq
 	title = "Serpentid Queen"
 	supervisors = "the Gyne"
+	requires_supervisor = "Ascent Gyne"
 	total_positions = 1
 	info = "You are a Monarch Serpentid Queen living on an independant Ascent vessel. Assist the Gyne in her duties and tend to your Workers."
 	set_species_on_join = SPECIES_MONARCH_QUEEN
@@ -200,7 +201,7 @@
 					SKILL_COMBAT = SKILL_ADEPT,
 					SKILL_WEAPONS = SKILL_ADEPT,
 					SKILL_MEDICAL = SKILL_BASIC)
-*/
+
 
 // Spawn points.
 /obj/effect/submap_landmark/spawnpoint/ascent_seedship


### PR DESCRIPTION
Enables Monarch serpentid Queen (relies on Gyne, think of her as her XO), adds adjucants (underlings of queen)
Adds specific injector inside rigs for serpentids

:cl: 
maptweak: Adds Serpentid gear inside ascent armory
rscadd: Enables Monarch Serpentid Queens (whitelisted) and Adjuncants
/:cl: