### PR TITLE
Long Corporate Labcoats for Science

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -156,3 +156,15 @@
 	display_name = "high-visibility jacket"
 	path = /obj/item/clothing/suit/storage/toggle/highvis
 	cost = 1
+
+/datum/gear/suit/labcoat_long
+	display_name = "long labcoat, corporate colors"
+	path = /obj/item/clothing/suit/storage/toggle/labcoat/roles/science/
+
+/datum/gear/suit/labcoat_long/New()
+	..()
+	var/longlabcoats = list()
+	longlabcoats += /obj/item/clothing/suit/storage/toggle/labcoat/roles/science/nanotrasen
+	longlabcoats += /obj/item/clothing/suit/storage/toggle/labcoat/roles/science/heph
+	longlabcoats += /obj/item/clothing/suit/storage/toggle/labcoat/roles/science/zeng
+	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(longlabcoats)

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -148,22 +148,22 @@
 	icon_closed = "labcoat_rd"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 
-/obj/item/clothing/suit/storage/toggle/labcoat/rd/nanotrasen
-	name = "\improper NT research director's labcoat"
+/obj/item/clothing/suit/storage/toggle/labcoat/roles/science/nanotrasen
+	name = "\improper NT long labcoat"
 	desc = "A full-body labcoat covered in red and black designs, denoting it as a NanoTrasen management coat. Judging by the amount of designs on it, it is only to be worn by the most enthusiastic of employees."
 	icon_state = "labcoat_rd_nt_open"
 	icon_open = "labcoat_rd_nt_open"
 	icon_closed = "labcoat_rd_nt"
 
-/obj/item/clothing/suit/storage/toggle/labcoat/rd/heph
-	name = "\improper HI research director's labcoat"
+/obj/item/clothing/suit/storage/toggle/labcoat/roles/science/heph
+	name = "\improper HI long labcoat"
 	desc = "A full-body labcoat covered in cyan and black designs, denoting it as a Hephaestus Industries management coat. Judging by the amount of designs on it, it is only to be worn by the most enthusiastic of employees."
 	icon_state = "labcoat_rd_heph_open"
 	icon_open = "labcoat_rd_heph_open"
 	icon_closed = "labcoat_rd_heph"
 
-/obj/item/clothing/suit/storage/toggle/labcoat/rd/zeng
-	name = "\improper Z-H research director's labcoat"
+/obj/item/clothing/suit/storage/toggle/labcoat/roles/science/zeng
+	name = "\improper Z-H long labcoat"
 	desc = "A full-body labcoat covered in cyan and black designs, denoting it as a Zeng-Hu Pharmaceuticals management coat. Judging by the amount of designs on it, it is only to be worn by the most enthusiastic of employees."
 	icon_state = "labcoat_rd_zeng_open"
 	icon_open = "labcoat_rd_zeng_open"

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -101,3 +101,7 @@
 	display_name = "Agent's jacket"
 	path = /obj/item/clothing/suit/storage/toggle/agent_jacket
 	allowed_roles = list(/datum/job/detective)
+
+/datum/gear/suit/labcoat_long
+	allowed_roles = DOCTOR_ROLES
+	allowed_branches = CASUAL_BRANCHES


### PR DESCRIPTION
Adds "long corporate labcoat" sprites as loadout options (like with regular corporate labcoats). NT, Heph, and Zeng styles.