### PR TITLE
ANFO and ANFO+ are now harder to make

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2373,35 +2373,36 @@
 /datum/chemical_reaction/anfo
 	name = "EZ-ANFO"
 	result = /datum/reagent/anfo
-	required_reagents = list(/datum/reagent/toxin/fertilizer/eznutrient=20, /datum/reagent/fuel=10)
+	required_reagents = list(/datum/reagent/toxin/fertilizer/eznutrient=30, /datum/reagent/fuel=15)
 	result_amount = 15
 	mix_message = "The solution gives off the eye-watering reek of spilled fertilizer and petroleum."
 
 /datum/chemical_reaction/anfo2
 	name = "Left 4 ANFO"
 	result = /datum/reagent/anfo
-	required_reagents = list(/datum/reagent/toxin/fertilizer/left4zed=10, /datum/reagent/fuel=5)
+	required_reagents = list(/datum/reagent/toxin/fertilizer/left4zed=20, /datum/reagent/fuel=10)
 	result_amount = 10
 	mix_message = "The solution gives off the eye-watering reek of spilled fertilizer and petroleum."
 
 /datum/chemical_reaction/anfo3
 	name = "Robust ANFO"
 	result = /datum/reagent/anfo
-	required_reagents = list(/datum/reagent/toxin/fertilizer/robustharvest=15, /datum/reagent/fuel=5)
+	required_reagents = list(/datum/reagent/toxin/fertilizer/robustharvest=30, /datum/reagent/fuel=10)
 	result_amount = 10
 	mix_message = "The solution gives off the eye-watering reek of spilled fertilizer and petroleum."
 
 /datum/chemical_reaction/anfo4
 	name = "Chemlab ANFO"
 	result = /datum/reagent/anfo
-	required_reagents = list(/datum/reagent/ammonia=10, /datum/reagent/fuel=5)
-	result_amount = 15
+	required_reagents = list(/datum/reagent/ammonia=20, /datum/reagent/fuel=20)
+	result_amount = 10
 	mix_message = "The solution gives off the eye-watering reek of spilled fertilizer and petroleum."
 
 /datum/chemical_reaction/anfo_plus
 	name = "ANFO+"
 	result = /datum/reagent/anfo/plus
 	required_reagents = list(/datum/reagent/anfo=15, /datum/reagent/aluminium=5)
+	catalysts = list(/datum/reagent/toxin/phoron = 5)
 	result_amount = 20
 	mix_message = "The solution gives off the eye-watering reek of spilled fertilizer and petroleum."
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
This PR increases the cost of fertilizer and fuel required to make ANFO, aswell as requiring phoron as a catalyst for ANFO+. ANFO+ bombs will still be viable, but deck-deleting ANFO+ bombs will be not, at least not without needing refills.

:cl: Vhbraz
tweak: ANFO and ANFO+ Recipes now require more/different reagents.
:cl: