### PR TITLE
Fix the buggy gas synthesizers

### DIFF
--- a/code/modules/skrell/skrell_rigs.dm
+++ b/code/modules/skrell/skrell_rigs.dm
@@ -213,10 +213,9 @@
 	icon = 'icons/obj/skrell.dmi'
 	icon_state = "skrelltank"
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
-	var/charge_cost = 0.01
 	var/refill_gas_type = GAS_OXYGEN
-	var/gas_regen_amount = 1
-	var/gas_regen_cap = 175
+	var/gas_regen_amount = 0.05
+	var/gas_regen_cap = 50
 
 /obj/item/weapon/tank/skrell/Initialize()
 	starting_pressure = list("[refill_gas_type]" = 6 * ONE_ATMOSPHERE)
@@ -224,8 +223,7 @@
 
 /obj/item/weapon/tank/skrell/Process()
 	..()
-	var/obj/item/weapon/rig/holder = loc
-	if(air_contents.total_moles < gas_regen_cap && istype(holder) && holder.cell && holder.cell.use(charge_cost))
+	if(air_contents.total_moles < gas_regen_cap)
 		air_contents.adjust_gas(refill_gas_type, gas_regen_amount)
 
 //Skrell Cluster Tool


### PR DESCRIPTION
My stupid ass put the gas regen cap too high. This will also allow them to regen outside of RIGs

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Vhbraz
bugfix: Skrellian gas synthesizers will no longer keep regenerating gas past 50 moles
tweak: Skrellian gas synthesizers now do not require power or being inside a RIG in order to create oxygen.
:cl: 