### PR TITLE
Adds a chemistry recipe for liquid corruption

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -55,8 +55,9 @@
 			if(beaker.reagents.total_volume < beaker.reagents.maximum_volume)
 				var/pumped = 0
 				for(var/datum/reagent/x in occupant.reagents.reagent_list)
-					occupant.reagents.trans_to_obj(beaker, pump_speed)
-					pumped++
+					if(x.filterable)
+						occupant.reagents.trans_to_obj(beaker, pump_speed)
+						pumped++
 				if(ishuman(occupant))
 					occupant.vessel.trans_to_obj(beaker, pumped + 1)
 		else

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -17,6 +17,7 @@
 	var/color_weight = 1
 	var/flags = 0
 	var/hidden_from_codex
+	var/filterable = TRUE // Can be filtered out via dialysis
 
 	var/glass_icon = DRINK_ICON_DEFAULT
 	var/glass_name = "something"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -978,6 +978,7 @@
 	hidden_from_codex = TRUE
 	heating_products = null
 	heating_point = null
+	filterable = FALSE
 
 /datum/reagent/zombie/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(!istype(M, /mob/living/carbon/human))
@@ -1007,7 +1008,7 @@
 		M.hallucination(50, min(true_dose/2, 50))
 		if(M.getBrainLoss() < 75)
 			M.adjustBrainLoss(rand(1,2))
-		if(prob(0.5))
+		if(prob(1))
 			H.seizure()
 			H.adjustBrainLoss(rand(12, 24))
 		if(prob(5))
@@ -1015,10 +1016,11 @@
 		M.bodytemperature += 9
 
 	if(true_dose >= 110)
-		M.adjustHalLoss(5)
+		M.adjustHalLoss(9)
 		M.make_dizzy(10)
 		if(prob(8))
 			to_chat(M, SPAN_DANGER("<font style='font-size:[rand(3,4)]'>[pick(stage3_messages)]</font>"))
+		M.bodytemperature += 5
 
 	if(true_dose >= 135)
 		if(prob(3))

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -491,6 +491,15 @@
 	required_reagents = list(/datum/reagent/inaprovaline = 1, /datum/reagent/hyperzine = 1, /datum/reagent/dexalinp = 1)
 	result_amount = 3
 
+/datum/chemical_reaction/zombie
+	name = "Liquid Corruption"
+	result = /datum/reagent/zombie
+	required_reagents = list(/datum/reagent/mutagen = 5, /datum/reagent/aslimetoxin = 1, /datum/reagent/three_eye = 1, /datum/reagent/toxin/venom = 1, /datum/reagent/toxin/bromide = 1)
+	result_amount = 5
+	minimum_temperature = 90 CELSIUS
+	maximum_temperature = 99 CELSIUS
+	mix_message = "The solution boils to produce a foul, crimson fluid. It appears to churn on its own accord."
+
 /* Solidification */
 /datum/chemical_reaction/phoronsolidification
 	name = "Solid Phoron"

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -170,7 +170,7 @@
 				var/obj/obstacle = locate(type) in dir
 				if(obstacle)
 					H.face_atom(obstacle)
-					obstacle.attack_generic(H, 10, "smashes")
+					obstacle.attack_hand(H)
 					break
 
 			walk_to(H, target.loc, 1, H.move_intent.move_delay*1.25)
@@ -189,10 +189,8 @@
 				if(H.Adjacent(target)) //Check we're still next to them
 					H.consume()
 
-		for(var/mob/living/M in hearers(H, 15))
-			if(target == M) //If our target is still nearby
-				return
-		target = null //Target lost
+		if(get_dist(H, target) > 30) //If target is no longer nearby
+			target = null //Target lost
 
 	else
 		if(!H.lying)


### PR DESCRIPTION
:cl: Slywater
rscadd: Adds a chemistry recipe for liquid corruption (5u unstable mutagen, 1u three eye, 1u spider venom, 1u bromide, 1u advanced slime toxin. Heat between 90 and 100C)
tweak: Liquid corruption can now be stemmed off (but not removed) via dialysis.
/:cl:

Plus some other small behavior tweaks

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->