### PR TITLE
(DNM) Ports pixel shifting!

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -261,6 +261,10 @@
 			mob.last_quick_move_time = world.time
 			mob.adjust_stamina(-(mob.get_stamina_used_per_step() * (1+mob.encumbrance())))
 		mob.handle_embedded_and_stomach_objects()
+	
+	//Ideally, this will reset any pixel shifting you did when you start moving
+	mob.pixel_x = mob.default_pixel_x //Reset pixel shifting x
+	mob.pixel_y = mob.default_pixel_y //Reset pixel shifting y
 
 	mob.moving = 0
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1009,6 +1009,34 @@
 	set hidden = 1
 	set_face_dir(client.client_dir(WEST))
 
+/mob/verb/eastshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_x <= 16)
+		pixel_x++
+
+/mob/verb/westshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_x >= -16)
+		pixel_x--
+
+/mob/verb/northshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_y <= 16)
+		pixel_y++
+
+/mob/verb/southshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_y >= -16)
+		pixel_y--
+
 /mob/proc/adjustEarDamage()
 	return
 


### PR DESCRIPTION
Brings the magic of pixelshifting to _your_ high roleplay environment! "Well Torque," you might be asking, "just what is pixelshifting?" Pixelshifting is a wonderful feature which allows you to move your mob/character's sprite up to 16 pixels in any cartesian (x/y) direction! Bear in mind that I am very very bad at programming so this might need some adjustment before it's completely ready.

:cl:
rscadd: pixel shifting, allowing mobs to adjust their positioning north/south/east/west, resetting when moving
/:cl: