### PR TITLE
Adjusts the availability of the Warrant Officer rank

### DIFF
--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -107,10 +107,12 @@
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/engineering/senior_engineer/marine
 	)
 	allowed_ranks = list(
+		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/fleet/e7,
 		/datum/mil_rank/fleet/e8,
 		/datum/mil_rank/fleet/w1,
 		/datum/mil_rank/fleet/w2,
+		/datum/mil_rank/marine_corps/e6,
 		/datum/mil_rank/marine_corps/e7,
 		/datum/mil_rank/marine_corps/e8,
 		/datum/mil_rank/marine_corps/w1,
@@ -163,7 +165,8 @@
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/nt_pilot,
 		/datum/mil_rank/fleet/w1,
-		/datum/mil_rank/fleet/w2
+		/datum/mil_rank/fleet/w2,
+		/datum/mil_rank/fleet/w3
 	)
 
 /datum/job/explorer
@@ -284,14 +287,10 @@
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/fleet/e7,
-		/datum/mil_rank/fleet/w1,
-		/datum/mil_rank/fleet/w2,
-		/datum/mil_rank/fleet/w3,
+		/datum/mil_rank/fleet/e8,
 		/datum/mil_rank/marine_corps/e6,
 		/datum/mil_rank/marine_corps/e7,
-		/datum/mil_rank/marine_corps/w1,
-		/datum/mil_rank/marine_corps/w2,
-		/datum/mil_rank/marine_corps/w3
+		/datum/mil_rank/marine_corps/e8
 	)
 
 /datum/job/detective
@@ -412,12 +411,12 @@
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/supply/deckofficer/marine
 	)
 	allowed_ranks = list(
+		/datum/mil_rank/fleet/w1,
 		/datum/mil_rank/fleet/w2,
-		/datum/mil_rank/fleet/w3,
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/marine_corps/w1,
 		/datum/mil_rank/marine_corps/w2,
-		/datum/mil_rank/marine_corps/w3,
 		/datum/mil_rank/marine_corps/o2,
 		/datum/mil_rank/marine_corps/o3
 	)


### PR DESCRIPTION
This PR does the following:-
- Gives Senior Engineer access to E6 back
- Makes the shuttle pilot able to take the CW3 rank
- Removes all Warrant Officer ranks from the Brig Chief, gives them E8 back
- Gives the Deck Officer access to W1/W2 instead of W2/W3

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->