### PR TITLE
Removing tiles now requires you to be in help intent.

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -92,6 +92,8 @@
 		deconstruct(user)
 		return
 	if(isCrowbar(C) && plated_tile)
+		if(user.a_intent != I_HELP)
+			return
 		hatch_open = !hatch_open
 		if(hatch_open)
 			playsound(src, 'sound/items/Crowbar.ogg', 100, 2)

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -11,6 +11,8 @@
 
 	if(flooring)
 		if(isCrowbar(C))
+			if(user.a_intent != I_HELP)
+				return
 			if(broken || burnt)
 				to_chat(user, "<span class='notice'>You remove the broken [flooring.descriptor].</span>")
 				make_plating()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

This PR makes it so you can only lift up floor tiles if you are in help intent. All credits go to Slywater.

:cl: Slywater
tweak: You can now only pry up tiles or catwalks with a crowbar on help intent.
/:cl: