### PR TITLE
Enables the Wartorn planet.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2637,6 +2637,7 @@
 #include "code\modules\overmap\exoplanets\planet_types\shrouded.dm"
 #include "code\modules\overmap\exoplanets\planet_types\snow.dm"
 #include "code\modules\overmap\exoplanets\planet_types\volcanic.dm"
+#include "code\modules\overmap\exoplanets\planet_types\wartorn.dm"
 #include "code\modules\overmap\ships\landable.dm"
 #include "code\modules\overmap\ships\ship.dm"
 #include "code\modules\overmap\ships\computers\engine_control.dm"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
This enables the unused planet_type "wartorn" on the game's files. I assume it was removed along with infantry, but now that they are back, there's no reason not to have this spawning in.

_unless it's horribly broken but I doubt that's the case_

:cl: Vhbraz
maptweak: Wartorn Planet is now a possible exoplanet spawn
/:cl: