### PR TITLE
Reduces the amount of loadout points & Starting skills for Biomech.

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -244,22 +244,17 @@
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/civ/contractor
 	)
-	min_skill = list(   SKILL_BUREAUCRACY   = SKILL_BASIC,
-						SKILL_COMPUTER		= SKILL_BASIC,
-	                    SKILL_MEDICAL       = SKILL_EXPERT,
+	min_skill = list(	SKILL_MEDICAL       = SKILL_ADEPT,
 	                    SKILL_ANATOMY       = SKILL_EXPERT,
-	                    SKILL_CHEMISTRY     = SKILL_BASIC,
 						SKILL_MECH          = HAS_PERK,
-						SKILL_ELECTRICAL    = SKILL_BASIC,
-	                    SKILL_CONSTRUCTION  = SKILL_BASIC,
 	                    SKILL_DEVICES       = SKILL_ADEPT)
 
 	max_skill = list(   SKILL_MEDICAL     = SKILL_EXPERT,
 	                    SKILL_ANATOMY     = SKILL_EXPERT,
 						SKILL_DEVICES     = SKILL_SPEC,
 						SKILL_SCIENCE     = SKILL_EXPERT,
-	                    SKILL_CHEMISTRY   = SKILL_EXPERT)
-	skill_points = 20
+	                    SKILL_CHEMISTRY   = SKILL_ADEPT)
+	skill_points = 16
 
 	access = list(access_maint_tunnels, access_research, access_petrov, access_petrov_maint, 
 					access_research, access_robotics, access_robotics_engineering, access_medical, 


### PR DESCRIPTION
I gave Biomech too many points and skills on the last PR. This should fix the powercreeping issues.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Vhbraz
tweak: Reduces the amount of starting skills and points for Biomechanical Technician.
/:cl: