### PR TITLE
Bluespace River is abandoned once more

### DIFF
--- a/maps/away/blueriver/blueriver-1.dmm
+++ b/maps/away/blueriver/blueriver-1.dmm
@@ -57,7 +57,6 @@
 /area/bluespaceriver/underground)
 "m" = (
 /obj/item/weapon/pickaxe/drill,
-/mob/living/simple_animal/hostile/syndicate/ranged/space,
 /turf/simulated/floor/asteroid,
 /area/bluespaceriver/underground)
 "n" = (
@@ -93,6 +92,10 @@
 /area/bluespaceriver/underground)
 "t" = (
 /obj/item/device/geiger,
+/turf/simulated/floor/asteroid,
+/area/bluespaceriver/underground)
+"u" = (
+/obj/structure/inflatable/wall,
 /turf/simulated/floor/asteroid,
 /area/bluespaceriver/underground)
 "v" = (
@@ -140,9 +143,29 @@
 /obj/structure/wall_frame/away,
 /turf/simulated/floor/asteroid,
 /area/bluespaceriver/underground)
-"P" = (
-/mob/living/simple_animal/hostile/syndicate/melee/space,
+"B" = (
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/asteroid,
+/area/bluespaceriver/underground)
+"E" = (
+/obj/item/inflatable/torn,
+/turf/simulated/floor/asteroid,
+/area/bluespaceriver/underground)
+"I" = (
+/mob/living/simple_animal/hostile/hive_alien/defender,
+/turf/simulated/floor/asteroid,
+/area/bluespaceriver/underground)
+"O" = (
+/obj/structure/inflatable/door,
+/turf/simulated/floor/asteroid,
+/area/bluespaceriver/underground)
+"P" = (
+/obj/random/junk,
+/turf/simulated/floor/asteroid,
+/area/bluespaceriver/underground)
+"R" = (
+/mob/living/simple_animal/hostile/hive_alien/defender,
+/turf/simulated/floor/away/blueriver/alienfloor,
 /area/bluespaceriver/underground)
 
 (1,1,1) = {"
@@ -2343,7 +2366,7 @@ a
 a
 a
 a
-k
+P
 k
 k
 w
@@ -2549,7 +2572,7 @@ a
 a
 k
 k
-k
+E
 k
 a
 a
@@ -2649,10 +2672,10 @@ a
 a
 a
 a
+u
+O
 k
 k
-k
-P
 a
 a
 a
@@ -4387,7 +4410,7 @@ k
 k
 k
 x
-k
+I
 k
 k
 k
@@ -4492,7 +4515,7 @@ k
 k
 k
 k
-k
+B
 a
 a
 a
@@ -5710,7 +5733,7 @@ c
 e
 c
 f
-f
+R
 f
 f
 f

--- a/maps/away/blueriver/blueriver-2.dmm
+++ b/maps/away/blueriver/blueriver-2.dmm
@@ -414,6 +414,7 @@
 "bq" = (
 /obj/structure/bed/chair/office/light,
 /obj/machinery/light,
+/mob/living/simple_animal/hostile/hive_alien/defender/wounded,
 /turf/simulated/floor/tiled,
 /area/bluespaceriver/ship)
 "br" = (
@@ -461,6 +462,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/mob/living/simple_animal/hostile/viscerator,
 /turf/simulated/floor/tiled,
 /area/bluespaceriver/ship)
 "bz" = (
@@ -822,11 +824,10 @@
 /turf/simulated/floor/tiled,
 /area/bluespaceriver/ship)
 "cH" = (
-/mob/living/simple_animal/hostile/syndicate/melee/space,
-/turf/simulated/floor/exoplanet/snow{
-	temperature = 240
-	},
-/area/bluespaceriver/ground)
+/obj/structure/bed/chair/office/light,
+/obj/item/weapon/grenade/spawnergrenade/manhacks,
+/turf/simulated/floor/tiled,
+/area/bluespaceriver/ship)
 "cI" = (
 /obj/effect/gibspawner/human,
 /turf/simulated/floor/exoplanet/snow{
@@ -851,7 +852,6 @@
 /obj/item/weapon/storage/secure/safe{
 	pixel_y = 24
 	},
-/mob/living/simple_animal/hostile/syndicate/ranged/space,
 /turf/simulated/floor/tiled,
 /area/bluespaceriver/ship)
 "hN" = (
@@ -869,16 +869,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/syndicate/melee/space,
 /turf/simulated/floor/tiled,
 /area/bluespaceriver/ship)
 "Co" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/wall/titanium,
-/area/bluespaceriver/ship)
-"Fv" = (
-/mob/living/simple_animal/hostile/syndicate/ranged/space,
-/turf/simulated/floor/tiled,
 /area/bluespaceriver/ship)
 "Lk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -2459,7 +2454,7 @@ ac
 an
 an
 bb
-aN
+cH
 ay
 ay
 ay
@@ -3273,7 +3268,7 @@ aw
 ay
 aI
 aQ
-Fv
+au
 bh
 aA
 aA
@@ -3578,7 +3573,7 @@ an
 an
 aC
 aK
-Fv
+au
 au
 bk
 bw
@@ -3899,7 +3894,7 @@ ac
 ac
 ac
 ac
-cH
+ac
 ac
 ac
 ac
@@ -4202,7 +4197,7 @@ ac
 ac
 ac
 ac
-cH
+ac
 ac
 ac
 ac


### PR DESCRIPTION
Yeah, so, turns out that taking a map based around some degree of discovery and intrigue before promptly throwing a bunch of random syndis in kinda ruins it.

This gets rid of random packs of redsuits with guns and replaces them with strange creatures that fit the theme of the expedition. More here than the normal version because unga dungas need something to shoot, but far less than the syndis.

Also adds a few very minor objects/items in the underground river part to make it less empty.