### PR TITLE
Ungunks the CO and XO's revolvers

### DIFF
--- a/code/modules/boh_misc/boxes.dm
+++ b/code/modules/boh_misc/boxes.dm
@@ -50,7 +50,7 @@
 /obj/item/gunbox/executive/attack_self(mob/living/user)
 	var/list/options = list()
 	options["Ballistic - ID locked Mk58"] = list(/obj/item/weapon/gun/projectile/pistol/command,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
-	options["Ballistic - 10mm Revolver"] = list(/obj/item/weapon/gun/projectile/revolver/medium/captain/xo,/obj/item/weapon/storage/fancy/cigar,/obj/item/ammo_magazine/speedloader/xo)
+	options["Ballistic - Magnum Revolver"] = list(/obj/item/weapon/gun/projectile/revolver/medium/captain/large/xo,/obj/item/weapon/storage/fancy/cigar,/obj/item/ammo_magazine/speedloader/magnum)
 	options["Energy - EPP"] = list(/obj/item/weapon/gun/energy/pulse_rifle/pistol/epp,/obj/item/documents/epp)
 	options["Energy - Smart Service Revolver"] = list(/obj/item/weapon/gun/energy/revolver/secure)
 	var/choice = input(user,"What type of equipment?") as null|anything in options

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -94,7 +94,8 @@
 	ammo_type = /obj/item/ammo_casing/pistol/magnum/large
 	caliber = CALIBER_PISTOL_MAGNUM_LARGE
 
-/obj/item/weapon/gun/projectile/revolver/medium/captain/xo
+/obj/item/weapon/gun/projectile/revolver/medium/captain/large/xo
 	name = "Final Argument"
 	desc = "A shiny al-Maliki & Mosley Autococker automatic revolver, with black accents. Marketed as the 'Revolver for the Modern Era'. This one has 'To the Executive of the NTSS Dagon' engraved on the grip."
-	ammo_type = /obj/item/projectile/bullet/pistol/xo
+	ammo_type = /obj/item/ammo_casing/pistol/magnum
+	caliber = CALIBER_PISTOL_MAGNUM

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -140,18 +140,19 @@
 	armor_penetration = 10
 	distance_falloff = 3
 
-//Ultimate Argument
+
 /obj/item/projectile/bullet/pistol/strong
+	damage = 50
+	armor_penetration = 10
+	
+//Ultimate Argument
+/obj/item/projectile/bullet/pistol/large
 	fire_sound = 'sound/weapons/gunshot/revolver_1.ogg'
 	damage = 50
 	shrapnel_chance_multiplier = 0.8
 	arterial_bleed_chance_multiplier = 0.8
 	distance_falloff = 2.5
 	armor_penetration = 15
-
-/obj/item/projectile/bullet/pistol/large
-	damage = 50
-	armor_penetration = 10
 
 //"rubber" bullets
 //Armor pen is to prevent them from being invalidated by ARMOR_BALLISTIC_MINOR, as has been the case.


### PR DESCRIPTION

:cl: OolongCow
tweak: changes the CO and XO's revolvers to use their proper projectile types. They were swapped for some unknown reason.
tweak: Added lethal ammunition back to the XO's revolver choice since all the other choices are lethal and it's no longer firing bullets meant for the CO's use.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->