### PR TITLE
Swapping Shock/Tac numbers

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1462,7 +1462,7 @@
 		/obj/item/clothing/accessory/ubac = 24,
 		/obj/item/clothing/accessory/armorplate = 8,
 		/obj/item/clothing/accessory/armorplate/medium = 6,
-		/obj/item/clothing/accessory/armorplate/tactical = 2,
-		/obj/item/clothing/accessory/armorplate/shock = 4)
+		/obj/item/clothing/accessory/armorplate/tactical = 4,
+		/obj/item/clothing/accessory/armorplate/shock = 2)
 	contraband = list(/obj/item/clothing/accessory/storage/bandolier = 2,/obj/item/clothing/accessory/storage/drop_pouches/black = 2)
 	


### PR DESCRIPTION
Shock are the expensive, niche plate that are OOCly quite useless. Tactical plates are the actual "go time" code blue/red defense and there needs to be enough for the sec guards.

:cl:
:tweak: Swaps the number of shock and tac plates in the sec armory vendor. Tac plates are more important than shock plates, and less niche/expensive as well.
/:cl: