### PR TITLE
Removes Marines from all Jobs except for a handful.

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -183,12 +183,15 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/roboticist
 	allowed_branches = list(
 		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/engineering/roboticist/fleet,
-		/datum/mil_branch/civilian)
+		/datum/mil_branch/civilian,
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/engineering/roboticist/marine)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/fleet/e6,
-		/datum/mil_rank/civ/contractor)
+		/datum/mil_rank/civ/contractor,
+		/datum/mil_rank/marine_corps/w1,
+		/datum/mil_rank/marine_corps/w2)
 	min_skill = list(   SKILL_COMPUTER		= SKILL_ADEPT,
 	                    SKILL_DEVICES		= SKILL_ADEPT,
 	                    SKILL_ANATOMY       = SKILL_ADEPT,
@@ -207,8 +210,8 @@
 	                    SKILL_ANATOMY      = SKILL_EXPERT)
 	skill_points = 24
 
-	access = list(access_robotics, access_robotics_engineering, access_nanotrasen, access_engine,
-					access_solgov_crew, access_maint_tunnels, access_research, access_petrov,
+	access = list(access_robotics, access_robotics_engineering, access_nanotrasen, access_engine, 
+					access_solgov_crew, access_maint_tunnels, access_research, access_petrov, 
 					access_petrov_maint, access_research,)
 	minimal_access = list()
 

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -183,15 +183,12 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/roboticist
 	allowed_branches = list(
 		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/engineering/roboticist/fleet,
-		/datum/mil_branch/civilian,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/engineering/roboticist/marine)
+		/datum/mil_branch/civilian)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/fleet/e6,
-		/datum/mil_rank/civ/contractor,
-		/datum/mil_rank/marine_corps/w1,
-		/datum/mil_rank/marine_corps/w2)
+		/datum/mil_rank/civ/contractor)
 	min_skill = list(   SKILL_COMPUTER		= SKILL_ADEPT,
 	                    SKILL_DEVICES		= SKILL_ADEPT,
 	                    SKILL_ANATOMY       = SKILL_ADEPT,
@@ -210,8 +207,8 @@
 	                    SKILL_ANATOMY      = SKILL_EXPERT)
 	skill_points = 24
 
-	access = list(access_robotics, access_robotics_engineering, access_nanotrasen, access_engine, 
-					access_solgov_crew, access_maint_tunnels, access_research, access_petrov, 
+	access = list(access_robotics, access_robotics_engineering, access_nanotrasen, access_engine,
+					access_solgov_crew, access_maint_tunnels, access_research, access_petrov,
 					access_petrov_maint, access_research,)
 	minimal_access = list()
 

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -232,14 +232,10 @@
 	economic_power = 8
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/biomech
 	allowed_branches = list(
-		/datum/mil_branch/expeditionary_corps,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/medical/biomech/marine,
 		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/biomech/fleet,
 		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/biomech
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/marine_corps/o2,
-		/datum/mil_rank/marine_corps/o3,
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/civ/contractor
@@ -256,8 +252,8 @@
 	                    SKILL_CHEMISTRY   = SKILL_ADEPT)
 	skill_points = 16
 
-	access = list(access_maint_tunnels, access_research, access_petrov, access_petrov_maint, 
-					access_research, access_robotics, access_robotics_engineering, access_medical, 
+	access = list(access_maint_tunnels, access_research, access_petrov, access_petrov_maint,
+					access_research, access_robotics, access_robotics_engineering, access_medical,
 					access_morgue, access_virology, access_maint_tunnels, access_emergency_storage,
 			        access_crematorium, access_chemistry, access_surgery,
 			        access_medical_equip, access_solgov_crew, access_senmed, access_hangar)

--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -12,14 +12,11 @@
 
 /datum/job/hop
 	allowed_branches = list(
-		/datum/mil_branch/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/XO/marine
+		/datum/mil_branch/fleet
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o4,
-		/datum/mil_rank/fleet/o5,
-		/datum/mil_rank/marine_corps/o4,
-		/datum/mil_rank/marine_corps/o5
+		/datum/mil_rank/fleet/o5
 	)
 
 /datum/job/rd
@@ -33,38 +30,29 @@
 
 /datum/job/cmo
 	allowed_branches = list(
-		/datum/mil_branch/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/cmo/marine
+		/datum/mil_branch/fleet
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o4,
-		/datum/mil_rank/fleet/o5,
-		/datum/mil_rank/marine_corps/o4,
-		/datum/mil_rank/marine_corps/o5
+		/datum/mil_rank/fleet/o5
 	)
 
 /datum/job/chief_engineer
 	allowed_branches = list(
-		/datum/mil_branch/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/chief_engineer/marine
+		/datum/mil_branch/fleet
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/fleet/o3,
-		/datum/mil_rank/marine_corps/o2,
-		/datum/mil_rank/marine_corps/o3
+		/datum/mil_rank/fleet/o3
 	)
 
 /datum/job/hos
 	allowed_branches = list(
-		/datum/mil_branch/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/cos/marine
+		/datum/mil_branch/fleet
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/fleet/o3,
-		/datum/mil_rank/marine_corps/o2,
-		/datum/mil_rank/marine_corps/o3
+		/datum/mil_rank/fleet/o3
 	)
 
 /datum/job/sea
@@ -89,63 +77,47 @@
 		"Sensor Operator"
 	)
 	allowed_branches = list(
-		/datum/mil_branch/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer/marine
+		/datum/mil_branch/fleet
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o1,
-		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/marine_corps/o1,
-		/datum/mil_rank/marine_corps/o2
+		/datum/mil_rank/fleet/o2
 	)
 /***/
 
 // Engineering
 /datum/job/senior_engineer
 	allowed_branches = list(
-		/datum/mil_branch/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/engineering/senior_engineer/marine
+		/datum/mil_branch/fleet
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/fleet/e7,
 		/datum/mil_rank/fleet/e8,
 		/datum/mil_rank/fleet/w1,
-		/datum/mil_rank/fleet/w2,
-		/datum/mil_rank/marine_corps/e6,
-		/datum/mil_rank/marine_corps/e7,
-		/datum/mil_rank/marine_corps/e8,
-		/datum/mil_rank/marine_corps/w1,
-		/datum/mil_rank/marine_corps/w2
+		/datum/mil_rank/fleet/w2
 
 	)
 
 /datum/job/engineer
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
-		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/engineering/contractor,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer/marine
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/engineering/contractor
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
-		/datum/mil_rank/marine_corps/e3,
-		/datum/mil_rank/marine_corps/e4,
-		/datum/mil_rank/marine_corps/e5,
 		/datum/mil_rank/civ/contractor
 	)
 
 /datum/job/engineer_trainee
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer/marine
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e2,
-		/datum/mil_rank/fleet/e3,
-		/datum/mil_rank/marine_corps/e2,
-		/datum/mil_rank/marine_corps/e3
+		/datum/mil_rank/fleet/e3
 	)
 /***/
 
@@ -189,59 +161,45 @@
 /datum/job/senior_doctor
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
-		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/senior,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/medical/senior/marine
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/senior
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o3,
 		/datum/mil_rank/fleet/o4,
-		/datum/mil_rank/marine_corps/o3,
-		/datum/mil_rank/marine_corps/o4,
 		/datum/mil_rank/civ/contractor
 	)
 
 /datum/job/doctor
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
-		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/medical/contractor,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/medical/doctor/marine
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/medical/contractor
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/fleet/e6,
-		/datum/mil_rank/marine_corps/e3,
-		/datum/mil_rank/marine_corps/e4,
-		/datum/mil_rank/marine_corps/e5,
-		/datum/mil_rank/marine_corps/e6,
 		/datum/mil_rank/civ/contractor
 	)
 
 /datum/job/medical_trainee
 	allowed_branches = list(
-		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/doctor/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/medical/doctor/marine
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/doctor/fleet
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e2,
-		/datum/mil_rank/fleet/e3,
-		/datum/mil_rank/marine_corps/e2,
-		/datum/mil_rank/marine_corps/e3
+		/datum/mil_rank/fleet/e3
 	)
 
 /datum/job/psychiatrist
 	allowed_branches = list(
 		/datum/mil_branch/civilian,
-		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/counselor/ec,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/medical/counselor/marine
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/counselor/ec
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/fleet/o3,
-		/datum/mil_rank/marine_corps/o2,
-		/datum/mil_rank/marine_corps/o3
+		/datum/mil_rank/fleet/o3
 	)
 /***/
 
@@ -287,16 +245,12 @@
 		"Warden"
 	)
 	allowed_branches = list(
-		/datum/mil_branch/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/security/brig_chief/marine
+		/datum/mil_branch/fleet
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/fleet/e7,
-		/datum/mil_rank/fleet/e8,
-		/datum/mil_rank/marine_corps/e6,
-		/datum/mil_rank/marine_corps/e7,
-		/datum/mil_rank/marine_corps/e8
+		/datum/mil_rank/fleet/e8
 	)
 
 /datum/job/detective
@@ -304,7 +258,6 @@
 		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/contractor,
 		/datum/mil_branch/private_security,
 		/datum/mil_branch/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/marine,
 		/datum/mil_branch/solgov = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/agent
 	)
 	allowed_ranks = list(
@@ -312,9 +265,7 @@
 		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/private_security/pcrc_agt = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/pcrc_agent,
-		/datum/mil_rank/sol/agent,
-		/datum/mil_rank/marine_corps/e4,
-		/datum/mil_rank/marine_corps/e5
+		/datum/mil_rank/sol/agent
 	)
 
 /datum/job/officer
@@ -378,19 +329,14 @@
 /datum/job/chef
 	allowed_branches = list(
 		/datum/mil_branch/civilian,
-		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/service/cook/ec,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/service/cook/marine
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/service/cook/ec
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/fleet/e2,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
-		/datum/mil_rank/fleet/e5,
-		/datum/mil_rank/marine_corps/e2,
-		/datum/mil_rank/marine_corps/e3,
-		/datum/mil_rank/marine_corps/e4,
-		/datum/mil_rank/marine_corps/e5
+		/datum/mil_rank/fleet/e5
 	)
 
 /datum/job/crew
@@ -413,35 +359,25 @@
 // Supply
 /datum/job/qm
 	allowed_branches = list(
-		/datum/mil_branch/fleet,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/supply/deckofficer/marine
+		/datum/mil_branch/fleet
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/w1,
 		/datum/mil_rank/fleet/w2,
 		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/fleet/o3,
-		/datum/mil_rank/marine_corps/w1,
-		/datum/mil_rank/marine_corps/w2,
-		/datum/mil_rank/marine_corps/o2,
-		/datum/mil_rank/marine_corps/o3
+		/datum/mil_rank/fleet/o3
 	)
 
 /datum/job/cargo_tech
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
-		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/supply/contractor,
-		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/supply/tech/marine
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/supply/contractor
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e2,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
-		/datum/mil_rank/marine_corps/e2,
-		/datum/mil_rank/marine_corps/e3,
-		/datum/mil_rank/marine_corps/e4,
-		/datum/mil_rank/marine_corps/e5,
 		/datum/mil_rank/civ/contractor
 	)
 /***/

--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -12,11 +12,14 @@
 
 /datum/job/hop
 	allowed_branches = list(
-		/datum/mil_branch/fleet
+		/datum/mil_branch/fleet,
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/XO/marine
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o4,
-		/datum/mil_rank/fleet/o5
+		/datum/mil_rank/fleet/o5,
+		/datum/mil_rank/marine_corps/o4,
+		/datum/mil_rank/marine_corps/o5
 	)
 
 /datum/job/rd
@@ -39,20 +42,26 @@
 
 /datum/job/chief_engineer
 	allowed_branches = list(
-		/datum/mil_branch/fleet
+		/datum/mil_branch/fleet,
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/chief_engineer/marine
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/fleet/o3
+		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/marine_corps/o2,
+		/datum/mil_rank/marine_corps/o3
 	)
 
 /datum/job/hos
 	allowed_branches = list(
-		/datum/mil_branch/fleet
+		/datum/mil_branch/fleet,
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/cos/marine
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/fleet/o3
+		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/marine_corps/o2,
+		/datum/mil_rank/marine_corps/o3
 	)
 
 /datum/job/sea
@@ -88,36 +97,49 @@
 // Engineering
 /datum/job/senior_engineer
 	allowed_branches = list(
-		/datum/mil_branch/fleet
+		/datum/mil_branch/fleet,
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/engineering/senior_engineer/marine
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/fleet/e7,
 		/datum/mil_rank/fleet/e8,
 		/datum/mil_rank/fleet/w1,
-		/datum/mil_rank/fleet/w2
+		/datum/mil_rank/fleet/w2,
+		/datum/mil_rank/marine_corps/e6,
+		/datum/mil_rank/marine_corps/e7,
+		/datum/mil_rank/marine_corps/e8,
+		/datum/mil_rank/marine_corps/w1,
+		/datum/mil_rank/marine_corps/w2
 
 	)
 
 /datum/job/engineer
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
-		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/engineering/contractor
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/engineering/contractor,
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer/marine
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
+		/datum/mil_rank/marine_corps/e3,
+		/datum/mil_rank/marine_corps/e4,
+		/datum/mil_rank/marine_corps/e5,
 		/datum/mil_rank/civ/contractor
 	)
 
 /datum/job/engineer_trainee
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer/marine
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e2,
-		/datum/mil_rank/fleet/e3
+		/datum/mil_rank/fleet/e3,
+		/datum/mil_rank/marine_corps/e2,
+		/datum/mil_rank/marine_corps/e3
 	)
 /***/
 
@@ -245,12 +267,16 @@
 		"Warden"
 	)
 	allowed_branches = list(
-		/datum/mil_branch/fleet
+		/datum/mil_branch/fleet,
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/security/brig_chief/marine
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e6,
 		/datum/mil_rank/fleet/e7,
-		/datum/mil_rank/fleet/e8
+		/datum/mil_rank/fleet/e8,
+		/datum/mil_rank/marine_corps/e6,
+		/datum/mil_rank/marine_corps/e7,
+		/datum/mil_rank/marine_corps/e8
 	)
 
 /datum/job/detective
@@ -258,6 +284,7 @@
 		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/contractor,
 		/datum/mil_branch/private_security,
 		/datum/mil_branch/fleet,
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/marine,
 		/datum/mil_branch/solgov = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/agent
 	)
 	allowed_ranks = list(
@@ -265,7 +292,9 @@
 		/datum/mil_rank/fleet/e5,
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/private_security/pcrc_agt = /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/pcrc_agent,
-		/datum/mil_rank/sol/agent
+		/datum/mil_rank/sol/agent,
+		/datum/mil_rank/marine_corps/e4,
+		/datum/mil_rank/marine_corps/e5
 	)
 
 /datum/job/officer
@@ -359,25 +388,35 @@
 // Supply
 /datum/job/qm
 	allowed_branches = list(
-		/datum/mil_branch/fleet
+		/datum/mil_branch/fleet,
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/supply/deckofficer/marine
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/w1,
 		/datum/mil_rank/fleet/w2,
 		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/fleet/o3
+		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/marine_corps/w1,
+		/datum/mil_rank/marine_corps/w2,
+		/datum/mil_rank/marine_corps/o2,
+		/datum/mil_rank/marine_corps/o3
 	)
 
 /datum/job/cargo_tech
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
-		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/supply/contractor
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/supply/contractor,
+		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/supply/tech/marine
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e2,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
+		/datum/mil_rank/marine_corps/e2,
+		/datum/mil_rank/marine_corps/e3,
+		/datum/mil_rank/marine_corps/e4,
+		/datum/mil_rank/marine_corps/e5,
 		/datum/mil_rank/civ/contractor
 	)
 /***/


### PR DESCRIPTION
- Removed Marines from Bridge officers. Reason: The ship is ran by the NTEF and Marine Officers aren't trained to navigate a ship. They're marines.
- ~Removed Marine XO. Reason: The XO is meant to be the second in command that takes care of berthing and also makes sure all personnel are kept in check. It makes no sense to have a Marine XO on a NTEF ship.~
- ~Removed marine command staff. Reason: The command structure of an NTEF ship should only be compromised of NTEF personnel.~
- Removed all marines from medical. Reason: Medical is the responsibility of NTEF and usually marines in any fiction or real life don't have their own doctors.
- ~Remove all marines from engineering. Reason: I actually do not have a valid argument for this. I'm willing to put them back if people find reason in the other removals.~
- ~Remove all marines from supply. Reason: Let NTEF run the logistics, not marines. Can maybe keep deck tech marines but the DO definitely has to stay NTEF.~
- ~Remove Marine BC. Reason: As the CoS's second in command, he should definitely be NTEF.~
- Remove Marines from Cooks. Reason: NTEF runs the ship, they should run accomodations.

As for what I kept.
- Kept Marine SEA. Reason: Will make a future PR, separate and regardless of this, to replace him with a Marine Officer Attache (O1/O2).
- Kept Marine MPs. Reason: You have marines on board, you'll need some MPs to keep the peace. This also will satisfy some people so.
- Kept Marine Chaplains. Reason: It's a chaplain.
- Kept Marine Janitors and Crewmen. Reason: NJP Duty.
- Kept Marine Infantry. Duh.

===================================================

Edit: After talks with maintainer, kept what was permitted.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->