### PR TITLE
Allows Physician to get expert complex devices.

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -34,6 +34,7 @@
 
 	max_skill = list(   SKILL_MEDICAL     = SKILL_SPEC,
 	                    SKILL_ANATOMY     = SKILL_SPEC,
+						SKILL_DEVICES     = SKILL_EXPERT,
 	                    SKILL_CHEMISTRY   = SKILL_EXPERT)
 	skill_points = 20
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Physicians already start with trained devices. Given we have biomechs, I will give them the possibility of getting expert devices instead of starting with it
:cl: Vhbraz
tweak: Physicians can now get expert devices.
/:cl: