### PR TITLE
Actually fixes the missing SL gunbox

### DIFF
--- a/maps/torch/structures/closets.dm
+++ b/maps/torch/structures/closets.dm
@@ -129,6 +129,7 @@
 		/obj/item/solbanner,
 		/obj/item/clothing/suit/armor/pcarrier/medium/sol,
 		/obj/item/gunbox/infcom,
+		/obj/item/gunbox/infcom/secondary,
 		/obj/item/device/gps,
 		/obj/item/weapon/storage/box/illumnades,
 		)

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -11669,9 +11669,6 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "vz" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/rig_module/device/healthscanner,
 /obj/item/rig_module/vision/medhud,
@@ -13915,9 +13912,6 @@
 	dir = 1;
 	health = 1e+006
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/light/spot{
 	dir = 4
 	},
@@ -14827,9 +14821,6 @@
 "HL" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/item/weapon/weldpack/bigwelder{
 	pixel_x = -2
 	},
@@ -15256,9 +15247,6 @@
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/crowbar,
 /obj/item/weapon/wrench,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/infantry)
@@ -16720,9 +16708,6 @@
 /area/shuttle/petrov/isolation)
 "Ps" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/weapon/storage/box/autoinjectors,
 /obj/item/weapon/storage/pill_bottle/dermaline{
@@ -16864,10 +16849,6 @@
 /area/shuttle/petrov/rd)
 "PU" = (
 /obj/machinery/vending/security/infantry,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = 1e+006
@@ -17246,9 +17227,6 @@
 /obj/item/weapon/crowbar,
 /obj/item/weapon/wrench,
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light/spot{
 	dir = 4


### PR DESCRIPTION
I'm shaking and crying right now begging GitHub Desktop "WHY ARE YOU LIKE THIS?"

:cl: OolongCow
tweak: The Squad Leader's gunbox should now properly spawn as intended. For some reason, despite a successfully merged PR supposedly adding it, it is nonexistent. I have no words.
tweak: Also removes some windows my brain was too small to see before.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->