### PR TITLE
Another skill rebalance

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -109,12 +109,12 @@
 	)
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
-	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_COMPUTER    = SKILL_ADEPT,
 	                    SKILL_FINANCE     = SKILL_ADEPT,
-	                    SKILL_BOTANY      = SKILL_BASIC,
+	                    SKILL_BOTANY      = SKILL_ADEPT,
 	                    SKILL_ANATOMY     = SKILL_BASIC,
-	                    SKILL_DEVICES     = SKILL_BASIC,
-	                    SKILL_SCIENCE     = SKILL_ADEPT)
+	                    SKILL_DEVICES     = SKILL_ADEPT,
+	                    SKILL_SCIENCE     = SKILL_EXPERT)
 
 	max_skill = list(   SKILL_ANATOMY     = SKILL_EXPERT,
 	                    SKILL_DEVICES     = SKILL_SPEC,
@@ -156,16 +156,17 @@
 		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/ec/o3
 	)
-	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
 	                    SKILL_MEDICAL     = SKILL_EXPERT,
 	                    SKILL_ANATOMY     = SKILL_EXPERT,
-	                    SKILL_CHEMISTRY   = SKILL_BASIC,
+	                    SKILL_CHEMISTRY   = SKILL_ADEPT,
 						SKILL_DEVICES     = SKILL_ADEPT)
 
 	max_skill = list(   SKILL_MEDICAL     = SKILL_SPEC,
 	                    SKILL_ANATOMY     = SKILL_SPEC,
-	                    SKILL_CHEMISTRY   = SKILL_EXPERT)
-	skill_points = 26
+	                    SKILL_CHEMISTRY   = SKILL_EXPERT,
+						SKILL_DEVICES     = SKILL_SPEC)
+	skill_points = 24
 
 	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_teleporter, access_eva, access_bridge, access_heads,
@@ -198,10 +199,10 @@
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3
 	)
-	min_skill = list(   SKILL_BUREAUCRACY  = SKILL_BASIC,
+	min_skill = list(   SKILL_BUREAUCRACY  = SKILL_ADEPT,
 	                    SKILL_COMPUTER     = SKILL_ADEPT,
 	                    SKILL_EVA          = SKILL_ADEPT,
-	                    SKILL_CONSTRUCTION = SKILL_ADEPT,
+	                    SKILL_CONSTRUCTION = SKILL_EXPERT,
 	                    SKILL_ELECTRICAL   = SKILL_ADEPT,
 	                    SKILL_ATMOS        = SKILL_ADEPT,
 	                    SKILL_ENGINES      = SKILL_EXPERT)
@@ -211,7 +212,7 @@
 	                    SKILL_ELECTRICAL   = SKILL_SPEC,
 	                    SKILL_ATMOS        = SKILL_SPEC,
 	                    SKILL_ENGINES      = SKILL_SPEC)
-	skill_points = 30
+	skill_points = 28
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_ai_upload, access_teleporter, access_eva, access_bridge, access_heads,
@@ -256,7 +257,7 @@
 	)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
 	                    SKILL_EVA         = SKILL_BASIC,
-	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_ADEPT,
 	                    SKILL_WEAPONS     = SKILL_ADEPT,
 	                    SKILL_FORENSICS   = SKILL_BASIC)
 

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -26,7 +26,7 @@
 						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_security,
 						access_petrov_maint, access_robotics, access_robotics_engineering)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
-	                    SKILL_COMPUTER    = SKILL_ADEPT,
+	                    SKILL_COMPUTER    = SKILL_BASIC,
 	                    SKILL_FINANCE     = SKILL_BASIC,
 	                    SKILL_BOTANY      = SKILL_BASIC,
 	                    SKILL_ANATOMY     = SKILL_BASIC,

--- a/maps/torch/job/service_jobs.dm
+++ b/maps/torch/job/service_jobs.dm
@@ -103,7 +103,7 @@
 		)
 	access = list(access_hydroponics, access_bar, access_solgov_crew, access_kitchen, access_commissary, access_maint_tunnels)
 	minimal_access = list()
-	min_skill = list(   SKILL_COOKING   = SKILL_BASIC,
+	min_skill = list(   SKILL_COOKING   = SKILL_ADEPT,
 	                    SKILL_BOTANY    = SKILL_BASIC,
 	                    SKILL_CHEMISTRY = SKILL_BASIC)
 	max_skill = list(	SKILL_COOKING   = SKILL_SPEC,

--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -173,8 +173,8 @@
 
 /datum/job/explorer
 	alt_titles = list(
-		"Technician Explorer" = /decl/hierarchy/outfit/job/torch/crew/exploration/technician,
-		"Medic Explorer" = /decl/hierarchy/outfit/job/torch/crew/exploration/medic
+		"Exploratory Technician" = /decl/hierarchy/outfit/job/torch/crew/exploration/technician,
+		"Exploratory Medic" = /decl/hierarchy/outfit/job/torch/crew/exploration/medic
 	)
 	allowed_branches = list(/datum/mil_branch/fleet)
 
@@ -183,7 +183,9 @@
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5
 	)
-	min_skill = list(SKILL_EVA = SKILL_BASIC, SKILL_SCIENCE = SKILL_BASIC) // To make up NT not having sci skill by default.
+	min_skill = list(SKILL_EVA     = SKILL_ADEPT,
+					 SKILL_SCIENCE = SKILL_BASIC,
+					 SKILL_COMBAT  = SKILL_BASIC)
 /***/
 
 // Medical

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -200,6 +200,11 @@
 		/datum/mil_rank/fleet/o6
 	)
 
+
+	min_skill = list(	SKILL_WEAPONS = SKILL_BASIC,
+						SKILL_COMBAT  = SKILL_BASIC,
+						SKILL_EVA     = SKILL_BASIC)
+
 /datum/mil_branch/marine_corps
 	name = "Solar Marine Corps"
 	name_short = "SMC"
@@ -264,8 +269,7 @@
 
 	min_skill = list(	SKILL_HAULING = SKILL_BASIC,
 						SKILL_WEAPONS = SKILL_BASIC,
-						SKILL_COMBAT  = SKILL_BASIC,
-						SKILL_EVA     = SKILL_BASIC)
+						SKILL_COMBAT  = SKILL_BASIC,)
 
 /*
  *  Fleet (NTEF Override)

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -268,7 +268,7 @@
 
 	min_skill = list(	SKILL_HAULING = SKILL_BASIC,
 						SKILL_WEAPONS = SKILL_BASIC,
-						SKILL_COMBAT  = SKILL_BASIC,)
+						SKILL_COMBAT  = SKILL_BASIC)
 
 /*
  *  Fleet (NTEF Override)

--- a/maps/torch/torch_ranks_boh.dm
+++ b/maps/torch/torch_ranks_boh.dm
@@ -201,8 +201,7 @@
 	)
 
 
-	min_skill = list(	SKILL_WEAPONS = SKILL_BASIC,
-						SKILL_COMBAT  = SKILL_BASIC,
+	min_skill = list(	SKILL_MEDICAL = SKILL_BASIC,
 						SKILL_EVA     = SKILL_BASIC)
 
 /datum/mil_branch/marine_corps


### PR DESCRIPTION
This PR edits multiple skills, mostly to give heads(CMO gets some chemistry and paperwork, Security chief gets trained CQC) and nerf seniors(senior researcher was better than CSO ~~and it wasn't me I promise~~).
Also, the most noticeable change - NTEF are now equal to SMC.
SMC gets basic CQC, WE, Athletics, NTEF gets basic ~~CQC, WE and EVA.~~ EVA and Medical.
![изображение](https://user-images.githubusercontent.com/57810301/97911845-fcc68f00-1d5c-11eb-904a-446a67c36727.png)

You can see more changes by looking at the code, it's rather easy.