### PR TITLE
Makes combi-knife actually function and fixes its tools.

### DIFF
--- a/code/game/objects/items/weapons/material/swiss.dm
+++ b/code/game/objects/items/weapons/material/swiss.dm
@@ -114,6 +114,13 @@
 		update_force()
 		return
 	if(istype(target, /obj))
+		if(active_tool == SWISSKNF_CROWBAR && !istype(target,/obj/item))
+			to_chat(user,"<span class = 'notice'>[src] doesn't provide the leverage to do that!</span>")
+			return
+		if(active_tool in list(SWISSKNF_CROWBAR, SWISSKNF_CLIFTER, SWISSKNF_COPENER, SWISSKNF_WCUTTER, SWISSKNF_WBLADE))
+			to_chat(user,"<span class = 'notice'>You start preparing to use [src]'s [active_tool] on [target]...</span>")
+			if(!do_after(user,3 SECONDS,src))
+				return
 		can_use_tools = TRUE
 		. = ..()
 		can_use_tools = FALSE

--- a/code/game/objects/items/weapons/material/swiss.dm
+++ b/code/game/objects/items/weapons/material/swiss.dm
@@ -32,7 +32,7 @@
 		LAZYSET(tool_icons, t, overlay_image(icon, t, flags=RESET_COLOR))
 
 /obj/item/weapon/material/knife/folding/swiss/attack_self(mob/user)
-	var/choice	
+	var/choice
 	if(user.a_intent != I_HELP && ((SWISSKNF_LBLADE in tools) || (SWISSKNF_SBLADE in tools)) && active_tool == SWISSKNF_CLOSED)
 		open = TRUE
 		choice = (SWISSKNF_LBLADE in tools) ? SWISSKNF_LBLADE : SWISSKNF_SBLADE
@@ -45,7 +45,7 @@
 		else
 			choice = SWISSKNF_CLOSED
 			open = FALSE
-	
+
 	if(!choice || (choice == active_tool) || !CanPhysicallyInteract(user))
 		return
 	if(choice == SWISSKNF_CLOSED)
@@ -56,7 +56,7 @@
 		user.visible_message("<span class='[(choice in sharp_tools) ? "warning" : "notice"]'>\The [user] opens the [lowertext(choice)].</span>")
 		if(choice == SWISSKNF_LBLADE || choice == SWISSKNF_SBLADE)
 			playsound(user, 'sound/weapons/flipblade.ogg', 15, 1)
-			
+
 	active_tool = choice
 	update_force()
 	update_icon()
@@ -102,7 +102,7 @@
 	return (active_tool == SWISSKNF_CLIFTER || active_tool == SWISSKNF_COPENER) && can_use_tools
 
 /obj/item/weapon/material/knife/folding/swiss/iswirecutter()
-	return active_tool == SWISSKNF_WCUTTER && can_use_tools
+	return active_tool == SWISSKNF_WCUTTER
 
 /obj/item/weapon/material/knife/folding/swiss/ishatchet()
 	return active_tool == SWISSKNF_WBLADE
@@ -113,12 +113,11 @@
 		. = ..()
 		update_force()
 		return
-	if(istype(target, /obj/item))
-		if(target.w_class <= ITEM_SIZE_NORMAL)
-			can_use_tools = TRUE
-			. = ..()
-			can_use_tools = FALSE
-			return
+	if(istype(target, /obj))
+		can_use_tools = TRUE
+		. = ..()
+		can_use_tools = FALSE
+		return
 	return ..()
 
 #undef SWISSKNF_CLOSED


### PR DESCRIPTION
Widens target choice so that combi-knife tools can actually function on most objects.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

:cl: BladeburstNINJA
tweak: Makes combi-knife functional
/:cl:
Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->