### PR TITLE
Adds 8 medical/engineering armbands to the E-armory

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -14830,6 +14830,9 @@
 	},
 /obj/item/stack/nanopaste,
 /obj/item/bodybag/rescue/loaded,
+/obj/item/clothing/accessory/armband/medblue,
+/obj/item/clothing/accessory/armband/medblue,
+/obj/item/clothing/accessory/armband/medblue,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)
 "aMC" = (
@@ -17392,6 +17395,34 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
+"bqQ" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/medical,
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/stack/nanopaste,
+/obj/item/bodybag/rescue/loaded,
+/obj/item/clothing/accessory/armband/medblue,
+/obj/item/clothing/accessory/armband/medblue,
+/obj/item/clothing/accessory/armband/medblue,
+/obj/item/clothing/accessory/armband/medblue,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "brb" = (
 /obj/structure/closet/crate,
 /obj/random/tank,
@@ -20274,6 +20305,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/clothing/accessory/armband/engine,
+/obj/item/clothing/accessory/armband/engine,
+/obj/item/clothing/accessory/armband/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)
 "fMb" = (
@@ -27932,6 +27966,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/item/clothing/accessory/armband/engine,
+/obj/item/clothing/accessory/armband/engine,
+/obj/item/clothing/accessory/armband/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)
 "qbN" = (
@@ -31717,6 +31754,8 @@
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/clothing/accessory/armband/engine,
+/obj/item/clothing/accessory/armband/engine,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)
 "vVe" = (
@@ -60705,7 +60744,7 @@ rFK
 aMB
 aNE
 vlw
-aMB
+bqQ
 aNE
 kyt
 aQt


### PR DESCRIPTION
This gives command staff the ability to recruit non-medical/non-engineering personnel to help in emergencies and give them identifying armbands.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->