### PR TITLE
Gives Prospector/Drill Technician/Salvage Technician Master EVA

### DIFF
--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -95,6 +95,7 @@
 	                    SKILL_PILOT   = SKILL_BASIC)
 
 	max_skill = list(   SKILL_PILOT       = SKILL_EXPERT,
+						SKILL_EVA         = SKILL_SPEC,
 						SKILL_HAULING     = SKILL_SPEC)
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/prospector


### PR DESCRIPTION
:cl: OolongCow
tweak: Salvagers/Miners now have the ability to take Master EVA
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->