### PR TITLE
Illumination grenades are no longer terrible

### DIFF
--- a/code/game/objects/items/weapons/grenades/light.dm
+++ b/code/game/objects/items/weapons/grenades/light.dm
@@ -7,10 +7,10 @@
 
 /obj/item/weapon/grenade/light/detonate()
 	..()
-	var/lifetime = rand(2 MINUTES, 4 MINUTES)
-	var/light_colour = pick("#49f37c", "#fc0f29", "#599dff", "#fa7c0b", "#fef923")
+	var/lifetime = rand(18 MINUTES, 20 MINUTES)
+	var/light_colour = pick("#599cff", "#ffda49", "#7860ff", "#ffbc49")
 
 	playsound(src, 'sound/effects/snap.ogg', 80, 1)
 	audible_message("<span class='warning'>\The [src] detonates with a sharp crack!</span>")
-	set_light(1, 1, 12, 2, light_colour)
+	set_light(1, 1, 16, 2, light_colour)
 	QDEL_IN(src, lifetime)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -683,7 +683,7 @@
 	name = "box of illumination grenades"
 	desc = "Designed to illuminate an area without the use of a flame or electronics, regardless of the atmosphere."
 	icon_state = "flashbang"
-	startswith = list(/obj/item/weapon/grenade/light = 6)
+	startswith = list(/obj/item/weapon/grenade/light = 8)
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/c4
 	name = "hefty bag"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -683,7 +683,7 @@
 	name = "box of illumination grenades"
 	desc = "Designed to illuminate an area without the use of a flame or electronics, regardless of the atmosphere."
 	icon_state = "flashbang"
-	startswith = list(/obj/item/weapon/grenade/light = 8)
+	startswith = list(/obj/item/weapon/grenade/light = 7)
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/c4
 	name = "hefty bag"

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -188,7 +188,7 @@
 	desc = "A shoulder-mounted micro-explosive dispenser designed only to accept standard illumination grenades."
 
 	charges = list(
-		list("illumination grenade",   "illumination grenade",   /obj/item/weapon/grenade/light,  6),
+		list("illumination grenade",   "illumination grenade",   /obj/item/weapon/grenade/light,  8),
 		)
 
 /obj/item/rig_module/mounted


### PR DESCRIPTION
:cl: OolongCow
tweak: MASSIVELY buffed the duration of illumination grenades, up from 2 to 4 minutes to 18 to 20.
tweak: the light from illumination grenades should be more pleasing to look at.
tweak: slightly buffed the light range of illumination grenades.
tweak: illumination grenade hardsuit modules and illumination grenade boxes hold slightly more grenades.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->