### PR TITLE
CO and XO gunbox changes round seven: Carl Boogaloo

### DIFF
--- a/code/modules/boh_misc/boxes.dm
+++ b/code/modules/boh_misc/boxes.dm
@@ -28,7 +28,7 @@
 /obj/item/gunbox/captain/attack_self(mob/living/user)
 	var/list/options = list()
 	options["Ballistic - .454 Revolver"] = list(/obj/item/weapon/gun/projectile/revolver/medium/captain/large,/obj/item/weapon/storage/fancy/cigar,/obj/item/ammo_magazine/speedloader/large)
-	options["Ballistic - Mk58 semi-automatic"] = list(/obj/item/weapon/gun/projectile/pistol/sec,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
+	options["Ballistic - Mk58 semi-automatic"] = list(/obj/item/weapon/gun/projectile/pistol/sec/lethal,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
 	options["Energy - EPP"] = list(/obj/item/weapon/gun/energy/pulse_rifle/pistol/epp,/obj/item/documents/epp)
 	options["Energy - Smart Service Revolver"] = list(/obj/item/weapon/gun/energy/revolver/secure)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
@@ -49,7 +49,7 @@
 
 /obj/item/gunbox/executive/attack_self(mob/living/user)
 	var/list/options = list()
-	options["Ballistic - Mk58 semi-automatic"] = list(/obj/item/weapon/gun/projectile/pistol/sec,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
+	options["Ballistic - Mk58 semi-automatic"] = list(/obj/item/weapon/gun/projectile/pistol/sec/lethal,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
 	options["Ballistic - Magnum Revolver"] = list(/obj/item/weapon/gun/projectile/revolver/medium/captain/large/xo,/obj/item/weapon/storage/fancy/cigar,/obj/item/ammo_magazine/speedloader/magnum)
 	options["Energy - EPP"] = list(/obj/item/weapon/gun/energy/pulse_rifle/pistol/epp,/obj/item/documents/epp)
 	options["Energy - Smart Service Revolver"] = list(/obj/item/weapon/gun/energy/revolver/secure)

--- a/code/modules/boh_misc/boxes.dm
+++ b/code/modules/boh_misc/boxes.dm
@@ -28,7 +28,7 @@
 /obj/item/gunbox/captain/attack_self(mob/living/user)
 	var/list/options = list()
 	options["Ballistic - .454 Revolver"] = list(/obj/item/weapon/gun/projectile/revolver/medium/captain/large,/obj/item/weapon/storage/fancy/cigar,/obj/item/ammo_magazine/speedloader/large)
-	options["Ballistic - ID locked Mk58"] = list(/obj/item/weapon/gun/projectile/pistol/command,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
+	options["Ballistic - Mk58 semi-automatic"] = list(/obj/item/weapon/gun/projectile/pistol/sec,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
 	options["Energy - EPP"] = list(/obj/item/weapon/gun/energy/pulse_rifle/pistol/epp,/obj/item/documents/epp)
 	options["Energy - Smart Service Revolver"] = list(/obj/item/weapon/gun/energy/revolver/secure)
 	var/choice = input(user,"What type of equipment?") as null|anything in options
@@ -49,7 +49,7 @@
 
 /obj/item/gunbox/executive/attack_self(mob/living/user)
 	var/list/options = list()
-	options["Ballistic - ID locked Mk58"] = list(/obj/item/weapon/gun/projectile/pistol/command,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
+	options["Ballistic - Mk58 semi-automatic"] = list(/obj/item/weapon/gun/projectile/pistol/sec,/obj/item/ammo_magazine/pistol,/obj/item/weapon/storage/fancy/cigar)
 	options["Ballistic - Magnum Revolver"] = list(/obj/item/weapon/gun/projectile/revolver/medium/captain/large/xo,/obj/item/weapon/storage/fancy/cigar,/obj/item/ammo_magazine/speedloader/magnum)
 	options["Energy - EPP"] = list(/obj/item/weapon/gun/energy/pulse_rifle/pistol/epp,/obj/item/documents/epp)
 	options["Energy - Smart Service Revolver"] = list(/obj/item/weapon/gun/energy/revolver/secure)

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -61,19 +61,6 @@
 /obj/item/weapon/gun/projectile/pistol/sec/lethal
 	magazine_type = /obj/item/ammo_magazine/pistol
 
-/obj/item/weapon/gun/projectile/pistol/command
-	name = "NT Mk58"
-	desc = "The NT Mk58 is a cheap, ubiquitous sidearm, produced by a NanoTrasen subsidiary. Found pretty much everywhere humans are. This one appears to be ID locked."
-	icon = 'icons/obj/guns/pistol.dmi'
-	icon_state = "secguncomp"
-	safety_icon = "safety"
-	magazine_type = /obj/item/ammo_magazine/pistol/rubber
-	accuracy = -1
-	fire_delay = 6
-	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
-	has_firing_pin = TRUE
-	firing_pin_type = /obj/item/firing_pin/id_locked/commanding_officer
-
 /obj/item/weapon/gun/projectile/pistol/magnum_pistol
 	name = "HT Magnus"
 	desc = "The HelTek Magnus, a robust Terran handgun that uses high-caliber ammo."


### PR DESCRIPTION
So apparently the ID-locked Mk58 the CO and XO could pick had an exclusively CO-locked firing pin, making picking it as XO worse than having no gun at all. It also had a really messy path that needlessly forced variables to be defined twice.

:cl: OolongCow
tweak: removed a messily copy-pasted gun
tweak: replaced the gun the CO and XO receive in their gunboxes with the (functionally identical) security version, which is not ID-locked.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->