### PR TITLE
Ascent prison cell fixes

### DIFF
--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -107,7 +107,6 @@
 /area/ship/ascent/subdeck_center)
 "ar" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	color = "#0000ff";
 	dir = 4
 	},
 /turf/simulated/floor/ascent,
@@ -307,7 +306,6 @@
 /area/ship/ascent/subdeck_atmos)
 "aS" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	color = "#ff0000";
 	dir = 4
 	},
 /turf/simulated/floor/ascent,
@@ -400,7 +398,6 @@
 "be" = (
 /obj/machinery/computer/air_control{
 	dir = 4;
-	frequency = 1441;
 	input_tag = "waste_tank";
 	name = "Waste Control";
 	output_tag = "";
@@ -418,8 +415,7 @@
 	},
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/meter{
-	name = "waste line meter";
-	pixel_y = 0
+	name = "waste line meter"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/subdeck_atmos)
@@ -830,7 +826,6 @@
 "bX" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/reagent_containers/glass/beaker/cryobromide{
-	item_state = "beaker";
 	name = "cryo beaker"
 	},
 /obj/item/weapon/reagent_containers/glass/beaker/cryobromide{
@@ -933,8 +928,7 @@
 "cg" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -1191,8 +1185,7 @@
 	frequency = 1331
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /obj/machinery/power/apc/hyper/ascent/west,
 /obj/structure/cable/cyan,
@@ -1206,8 +1199,7 @@
 /area/ship/ascent/subdeck_hospital)
 "cH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/subdeck_hospital)
@@ -1342,7 +1334,6 @@
 "cV" = (
 /obj/machinery/computer/air_control{
 	dir = 4;
-	frequency = 1441;
 	input_tag = "bromide_tank";
 	name = "Bromide Supply Control";
 	output_tag = "bromide_tank";
@@ -1357,8 +1348,7 @@
 "cW" = (
 /obj/machinery/light/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/subdeck_hospital)
@@ -1555,8 +1545,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/subdeck_north)
@@ -1624,8 +1613,7 @@
 "dy" = (
 /obj/structure/bed/chair/padded/purple/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	icon_state = "intact-supply"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/subdeck_atmos)
@@ -1647,7 +1635,6 @@
 	dir = 4;
 	max_pressure_setting = 30000;
 	name = "distro pressure regulator";
-	regulate_mode = 2;
 	target_pressure = 250;
 	use_power = 1
 	},

--- a/maps/away/ascent/ascent-2.dmm
+++ b/maps/away/ascent/ascent-2.dmm
@@ -40,8 +40,7 @@
 /area/ship/ascent/wing_starboard)
 "al" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/wall/r_wall/ascent,
 /area/ship/ascent/shuttle_starboard)
@@ -1427,9 +1426,7 @@
 /area/ship/ascent/wing_starboard)
 "dd" = (
 /obj/machinery/light/ascent,
-/obj/machinery/body_scanconsole/ascent{
-	dir = 2
-	},
+/obj/machinery/body_scanconsole/ascent,
 /obj/structure/table/rack/shelf/steel,
 /obj/item/roller,
 /turf/simulated/floor/tiled/ascent,
@@ -2014,7 +2011,6 @@
 /area/ship/ascent/wing_starboard)
 "eo" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
 	frequency = 1333;
 	id_tag = "ascent_starboard_pump_out_internal"
 	},
@@ -2023,7 +2019,6 @@
 	frequency = 1333;
 	id_tag = "ascent_starboard";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access = list("ACCESS_ASCENT");
 	tag_exterior_sensor = "ascent_starboard_sensor"
 	},
@@ -2262,7 +2257,6 @@
 	frequency = 1332;
 	id_tag = "ascent_port_dock";
 	pixel_x = -24;
-	pixel_y = 0;
 	tag_airpump = "ascent_port_dock_pump";
 	tag_chamber_sensor = "ascent_port_dock_sensor";
 	tag_exterior_door = "ascent_port_dock_outer";
@@ -2459,8 +2453,7 @@
 /obj/machinery/airlock_sensor{
 	frequency = 1333;
 	id_tag = "ascent_starboard_sensor";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -2489,7 +2482,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
 	frequency = 1333;
 	id_tag = "ascent_starboard_pump_out_internal"
 	},
@@ -2867,8 +2859,7 @@
 /area/ship/ascent/bridge)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
@@ -3181,8 +3172,7 @@
 	pixel_y = 32
 	},
 /obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_starboard_prow)
@@ -3293,7 +3283,6 @@
 /area/ship/ascent/wing_starboard)
 "gI" = (
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	color = "#ff0000";
 	dir = 4
 	},
 /turf/simulated/open/mantid,
@@ -3719,8 +3708,7 @@
 	command = "cycle_exterior";
 	frequency = 1333;
 	master_tag = "ascent_starboard";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
@@ -3733,7 +3721,6 @@
 /obj/effect/catwalk_plated/ascent,
 /obj/structure/hygiene/sink/ascent{
 	dir = 1;
-	icon_state = "sink";
 	pixel_y = 28
 	},
 /turf/simulated/floor/ascent,
@@ -4298,8 +4285,7 @@
 /obj/machinery/airlock_sensor{
 	frequency = 1333;
 	id_tag = "ascent_starboard_sensor_external";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
@@ -4414,7 +4400,6 @@
 	frequency = 1333;
 	id_tag = "ascent_starboard_dock";
 	pixel_x = -24;
-	pixel_y = 0;
 	tag_airpump = "ascent_shuttle_starboard_vent_inner";
 	tag_chamber_sensor = "ascent_shuttle_starboard_interior_sensor";
 	tag_exterior_door = "ascent_dock_starboard_external";
@@ -4543,13 +4528,13 @@
 /area/ship/ascent/shuttle_starboard)
 "vY" = (
 /obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
+	dir = 4
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "wd" = (
 /obj/machinery/door/window/brigdoor{
+	autoset_access = 1;
 	color = "PURPLE";
 	dir = 4;
 	req_access = list()
@@ -4580,7 +4565,6 @@
 /area/ship/ascent/aft_starboard_jut)
 "wO" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
 	frequency = 1333;
 	id_tag = "ascent_starboard_pump_out_internal"
 	},
@@ -4685,7 +4669,6 @@
 "AI" = (
 /obj/machinery/mineral/stacking_machine{
 	color = "PURPLE";
-	input_turf = 4;
 	name = "materials distributor";
 	output_turf = 2
 	},
@@ -4722,8 +4705,7 @@
 	name = "heavy duty box"
 	},
 /obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1"
+	dir = 8
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
@@ -4823,8 +4805,7 @@
 "IQ" = (
 /obj/effect/wallframe_spawn/reinforced_phoron/hull,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
@@ -5028,8 +5009,7 @@
 /area/ship/ascent/fore_starboard_jut)
 "QT" = (
 /obj/structure/hygiene/shower/ascent{
-	dir = 1;
-	icon_state = "shower"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_hallway)
@@ -5081,8 +5061,7 @@
 /area/ship/ascent/shuttle_starboard)
 "TO" = (
 /obj/structure/hygiene/shower/ascent{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_hallway)
@@ -5132,8 +5111,7 @@
 /area/ship/ascent/shuttle_starboard)
 "Vx" = (
 /obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_starboard_prow)


### PR DESCRIPTION
whoever mapped them never set autoset_access to 1 or added ACCESS_ASCENT to req_access 5head

:cl: OolongCow
maptweak: sets autoset_access on Ascent prison cells to 1, they should now function properly
maptweak: StrongDMM also sanitized a bunch of unnecessarily-defined variables on the Ascent z-level they're on. Bonus tweak.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->