### PR TITLE
Boron Fushion

### DIFF
--- a/code/datums/supplypacks/dispcarts.dm
+++ b/code/datums/supplypacks/dispcarts.dm
@@ -61,6 +61,10 @@ SEC_PACK(cognac,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/cogna
 SEC_PACK(ale,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/ale,      "Reagent refill - Ale",      "ale reagent cartridge crate",      15, access_bar)
 SEC_PACK(mead,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/mead,     "Reagent refill - Mead",     "mead reagent cartridge crate",     15, access_bar)
 
+// Engineering-restricted
+//
+SEC_PACK(boron,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/boron,   "Reagent refill - Boron",    "boron reagent cartridge crate",    15, access_engine)
+
 // Unrestricted (water, sugar, non-alcoholic drinks)
 //  Datum path   Contents type                                                       Supply pack name                        Container name                                          Cost
 PACK(water,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/water,      "Reagent refill - Water",               "water reagent cartridge crate",                         15)

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -162,6 +162,6 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 	s_react = GAS_HYDROGEN
 	minimum_energy_level = 15000
 	energy_consumption = 3
-	energy_production = 15
+	energy_production = 12
 	radiation = 3
-	instability = 3
+	instability = 2.5

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -160,7 +160,7 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 /decl/fusion_reaction/boron_hydrogen
 	p_react = "boron"
 	s_react = GAS_HYDROGEN
-	minimum_energy_level = FUSION_HEAT_CAP * 0.5
+	minimum_energy_level = 15000
 	energy_consumption = 3
 	energy_production = 15
 	radiation = 3

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -1147,3 +1147,12 @@
 	H.weedlevel += removed*strength*0.05
 	seed.set_trait(TRAIT_POTENCY, seed.get_trait(TRAIT_POTENCY) + removed*0.1, 200, 0)
 	return
+
+/datum/reagent/toxin/boron
+	name = "Boron"
+	description = "A chemical that is highly valued in fusion energy."
+	taste_description = "metal"
+	reagent_state = SOLID
+	color = "#837E79"
+	value = 4
+	strength = 7

--- a/code/modules/reagents/dispenser/cartridge_presets.dm
+++ b/code/modules/reagents/dispenser/cartridge_presets.dm
@@ -113,3 +113,6 @@
 	chloral		spawn_reagent = /datum/reagent/chloralhydrate
 	cryoxadone	spawn_reagent = /datum/reagent/cryoxadone
 	clonexadone	spawn_reagent = /datum/reagent/clonexadone
+
+	// Engineering
+	boron		spawn_reagent = /datum/reagent/toxin/boron


### PR DESCRIPTION
Addings Boron cartridges to supply.
You cans use these cartridges in the Tokamak.
The Tokamak makings lots of power with Boron and Hydrogen.
Power is importants for run the ship.

Fun tidbit: The temperature needed for the Boron reaction used to literally be 1/2 of the temperature of the core of the sun.
Notes: This reaction generates a lot of instability, so a higher power setting is required on the gyrotron when operating.
Maximum safe output should reach about 8 megawatts.
You'll need to take some precautions in preparation for grid checks, since they turn off SMES output, while the gyrotron feeds off the RUST SMES. The injectors don't stop, meaning the instability will keep rising. I have not tested this personally, but hooking up the gyrotron directly to the RUST should work.