### PR TITLE
Changes the title of department heads from 'Chief' to 'Head'

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -209,26 +209,26 @@
 	ks1type = /obj/item/device/encryptionkey/heads/hos
 
 /obj/item/device/radio/headset/heads/ce
-	name = "chief engineer's headset"
+	name = "head of engineering's headset"
 	desc = "The headset of the guy who is in charge of morons."
 	icon_state = "com_headset"
 	item_state = "headset"
 	ks1type = /obj/item/device/encryptionkey/heads/ce
 
 /obj/item/device/radio/headset/heads/ce/alt
-	name = "chief engineer's bowman headset"
+	name = "head of engineering's bowman headset"
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
 
 /obj/item/device/radio/headset/heads/cmo
-	name = "chief medical officer's headset"
+	name = "head of medical's headset"
 	desc = "The headset of the highly trained medical chief."
 	icon_state = "com_headset"
 	item_state = "headset"
 	ks1type = /obj/item/device/encryptionkey/heads/cmo
 
 /obj/item/device/radio/headset/heads/cmo/alt
-	name = "chief medical officer's bowman headset"
+	name = "head of medical's bowman headset"
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
 

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -14,14 +14,14 @@
 	restricted_accessory_slots = list(ACCESSORY_SLOT_ARMBAND)
 
 /obj/item/clothing/suit/storage/toggle/labcoat/cmo
-	name = "chief medical officer's labcoat"
+	name = "head of medical's labcoat"
 	desc = "Bluer than the standard model."
 	icon_state = "labcoat_cmo_open"
 	icon_open = "labcoat_cmo_open"
 	icon_closed = "labcoat_cmo"
 
 /obj/item/clothing/suit/storage/toggle/labcoat/cmoalt
-	name = "chief medical officer labcoat"
+	name = "head of medical's labcoat"
 	desc = "A labcoat with command blue highlights."
 	icon_state = "labcoat_cmoalt_open"
 	icon_open = "labcoat_cmoalt_open"
@@ -74,7 +74,7 @@
 	icon_open = "labcoat_xy_open"
 	icon_closed = "labcoat_xy"
 	armor = list(
-		melee = ARMOR_MELEE_MINOR, 
+		melee = ARMOR_MELEE_MINOR,
 		bio = ARMOR_BIO_MINOR
 		)
 	species_restricted = list(SPECIES_IPC)
@@ -170,7 +170,7 @@
 	icon_closed = "labcoat_rd_zeng"
 
 /obj/item/clothing/suit/storage/toggle/labcoat/rd/ec
-	name = "chief science officer's labcoat"
+	name = "head of research's labcoat"
 	desc = "A coat that protects against minor chemical spills. It has purple stripes on the shoulders denoting it as an Expeditionary Corps labcoat, and purple trim to indicate a Chief Science Officer."
 	icon_state = "labcoat_cso_open"
 	icon_open = "labcoat_cso_open"

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -16,15 +16,15 @@
 	icon_state = "stamp-cap"
 
 /obj/item/weapon/stamp/ce
-	name = "chief engineer's rubber stamp"
+	name = "head of engineering's rubber stamp"
 	icon_state = "stamp-ce"
 
 /obj/item/weapon/stamp/rd
-	name = "chief science officer's rubber stamp"
+	name = "head of research's rubber stamp"
 	icon_state = "stamp-rd"
 
 /obj/item/weapon/stamp/cmo
-	name = "chief medical officer's rubber stamp"
+	name = "head of medical's rubber stamp"
 	icon_state = "stamp-cmo"
 
 /obj/item/weapon/stamp/denied

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -82,7 +82,7 @@
 
 /obj/item/weapon/gun/projectile/pistol/magnum_pistol/solar
 	name = "Eagle"
-	desc = "The HI Eagle, a reverse engineered HT Magnus. This one has 'To the Chief of Security Aboard the NTSS Dagon' engraved"
+	desc = "The HI Eagle, a reverse engineered HT Magnus. This one has 'To the Head of Security Aboard the NTSS Dagon' engraved"
 	magazine_type = /obj/item/ammo_magazine/magnum/rubber
 	starts_loaded = 1
 

--- a/maps/torch/items/headsets.dm
+++ b/maps/torch/items/headsets.dm
@@ -42,7 +42,7 @@
 	item_state = "nt_headset_alt"
 
 /obj/item/device/radio/headset/heads/torchntdirector
-	name = "chief science officer headset"
+	name = "head of research's headset"
 	desc = "Headset of the masters of the universe."
 	icon_state = "sci_headset"
 	item_state = "headset"
@@ -54,14 +54,14 @@
 	item_state = "nt_headset_alt"
 
 /obj/item/device/radio/headset/heads/cos
-	name = "chief of security's headset"
+	name = "head of security's headset"
 	desc = "The headset of the man who protects your worthless lives."
 	icon_state = "com_headset"
 	item_state = "headset"
 	ks1type = /obj/item/device/encryptionkey/heads/hos
 
 /obj/item/device/radio/headset/heads/cos/alt
-	name = "chief of security's bowman headset"
+	name = "head of security's bowman headset"
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
 

--- a/maps/torch/items/stamps.dm
+++ b/maps/torch/items/stamps.dm
@@ -15,7 +15,7 @@
 	icon_state = "stamp-xo"
 
 /obj/item/weapon/stamp/cos
-	name = "chief of security's rubber stamp"
+	name = "head of security's rubber stamp"
 	icon_state = "stamp-cos"
 
 /obj/item/weapon/stamp/brig

--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -23,6 +23,7 @@
 	)
 
 /datum/job/rd
+	title = "Head of Research"
 	allowed_branches = list(
 		/datum/mil_branch/fleet
 	)
@@ -32,6 +33,7 @@
 	)
 
 /datum/job/cmo
+	title = "Head of Medical"
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/cmo/marine
@@ -44,6 +46,7 @@
 	)
 
 /datum/job/chief_engineer
+	title = "Head of Engineering"
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/chief_engineer/marine
@@ -56,6 +59,7 @@
 	)
 
 /datum/job/hos
+	title = "Head of Security"
 	allowed_branches = list(
 		/datum/mil_branch/fleet,
 		/datum/mil_branch/marine_corps = /decl/hierarchy/outfit/job/torch/crew/command/cos/marine

--- a/maps/torch/structures/closets/engineering.dm
+++ b/maps/torch/structures/closets/engineering.dm
@@ -31,7 +31,7 @@
 	)
 
 /obj/structure/closet/secure_closet/engineering_chief_torch
-	name = "chief engineer's locker"
+	name = "head of engineering's locker"
 	req_access = list(access_ce)
 	closet_appearance = /decl/closet_appearance/secure_closet/torch/engineering/ce
 	storage_capacity = 45

--- a/maps/torch/structures/closets/medical.dm
+++ b/maps/torch/structures/closets/medical.dm
@@ -26,7 +26,7 @@
 	closet_appearance = /decl/closet_appearance/secure_closet/torch/medical
 
 /obj/structure/closet/secure_closet/CMO_torch
-	name = "chief medical officer's locker"
+	name = "head of medical's locker"
 	req_access = list(access_cmo)
 	closet_appearance = /decl/closet_appearance/secure_closet/torch/medical/cmo
 

--- a/maps/torch/structures/closets/research.dm
+++ b/maps/torch/structures/closets/research.dm
@@ -17,7 +17,7 @@
 	)
 
 /obj/structure/closet/secure_closet/RD_torch
-	name = "chief science officer's locker"
+	name = "head of research's locker"
 	req_access = list(access_rd)
 	closet_appearance = /decl/closet_appearance/secure_closet/torch/science/cso
 

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -63,7 +63,7 @@
 
 
 /obj/structure/closet/secure_closet/cos
-	name = "chief of security's locker"
+	name = "head of security's locker"
 	req_access = list(access_hos)
 	closet_appearance = /decl/closet_appearance/secure_closet/torch/security/hos
 	storage_capacity = 45

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -14346,13 +14346,13 @@
 "Gc" = (
 /obj/structure/table/glass,
 /obj/machinery/photocopier/faxmachine{
-	department = "Chief Science Officer's Office"
+	department = "Head of Research - Polyp"
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
-	department = "Chief Science Officer's Desk";
+	department = "Head of Research's Desk";
 	departmentType = 5;
-	name = "Chief Science Officer RC";
+	name = "Head of Research RC";
 	pixel_x = -30
 	},
 /turf/simulated/floor/lino,
@@ -17997,7 +17997,7 @@
 "UM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
-	name = "Chief Science Officer";
+	name = "Head of Research";
 	secured_wires = 1
 	},
 /obj/structure/cable/cyan{

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -1740,7 +1740,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	id_tag = "csodoor";
-	name = "Chief Science Officer";
+	name = "Head of Research";
 	secured_wires = 1
 	},
 /obj/structure/cable/green{
@@ -1990,7 +1990,7 @@
 /obj/machinery/door/window/brigdoor/westright{
 	autoset_access = 0;
 	dir = 4;
-	name = "CMO's suit storage";
+	name = "HoM's suit storage";
 	req_access = list("ACCESS_CHIEF_MEDICAL_OFFICER")
 	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -2223,7 +2223,7 @@
 /obj/item/weapon/rcd_ammo,
 /obj/item/weapon/rcd_ammo,
 /obj/machinery/door/window/brigdoor/eastleft{
-	name = "CE's Equipment Storage"
+	name = "HoE's Equipment Storage"
 	},
 /obj/structure/window/reinforced{
 	dir = 2;
@@ -2309,7 +2309,7 @@
 /obj/machinery/button/alternate/door{
 	desc = "A remote control-switch for the office door.";
 	id_tag = "cedoor";
-	name = "CE's Office Door Control";
+	name = "HoE's Office Door Control";
 	pixel_x = 0;
 	pixel_y = -27;
 	req_access = list("ACCESS_CHIEF_ENGINEER")
@@ -3432,7 +3432,7 @@
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/brigdoor/westright{
-	name = "CE's Equipment Storage";
+	name = "HoE's Equipment Storage";
 	req_access = list("ACCESS_CHIEF_ENGINEER")
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -4083,7 +4083,7 @@
 /obj/machinery/door/window/brigdoor/westright{
 	autoset_access = 0;
 	dir = 4;
-	name = "CoS' suit storage";
+	name = "HoS's suit storage";
 	req_access = list("ACCESS_HEAD_OF_SECURITY")
 	},
 /obj/effect/floor_decal/corner/red/full,
@@ -4385,7 +4385,7 @@
 /obj/machinery/button/alternate/door{
 	desc = "A remote control-switch for the office door.";
 	id_tag = "cosdoor";
-	name = "COS's Office Door Control";
+	name = "HoS's Office Door Control";
 	pixel_x = 0;
 	pixel_y = 27;
 	req_access = list("ACCESS_HEAD_OF_SECURITY")
@@ -4490,7 +4490,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/engineering{
 	id_tag = "cedoor";
-	name = "Chief Engineer";
+	name = "Head of Engineering";
 	secured_wires = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -4728,7 +4728,7 @@
 /obj/machinery/door/window/brigdoor/westright{
 	autoset_access = 0;
 	dir = 4;
-	name = "CSO's suit storage";
+	name = "HoR's suit storage";
 	req_access = list("ACCESS_RESEARCH_DIRECTOR")
 	},
 /obj/item/weapon/rig/hazmat/equipped,
@@ -7681,7 +7681,7 @@
 	pixel_x = 20
 	},
 /obj/machinery/photocopier/faxmachine{
-	department = "COS"
+	department = "Head of Security"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
@@ -9801,7 +9801,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	id_tag = "cosdoor";
-	name = "Chief of Security";
+	name = "Head of Security";
 	secured_wires = 1
 	},
 /obj/structure/cable/green{
@@ -9873,9 +9873,9 @@
 "qu" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
+	department = "Head of Medical's Desk";
 	departmentType = 5;
-	name = "Chief Medical Officer RC";
+	name = "Head of Medical RC";
 	pixel_x = 32;
 	pixel_y = 0
 	},
@@ -14047,7 +14047,7 @@
 /obj/machinery/button/alternate/door{
 	desc = "A remote control-switch for the office door.";
 	id_tag = "cmodoor";
-	name = "CMO's Office Door Control";
+	name = "HoM's Office Door Control";
 	pixel_x = -5;
 	pixel_y = -35;
 	req_access = list("ACCESS_CHIEF_MEDICAL_OFFICER")
@@ -14675,9 +14675,9 @@
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
+	department = "Head of Engineering's Desk";
 	departmentType = 6;
-	name = "Chief Engineer RC";
+	name = "Head of Engineering RC";
 	pixel_x = 32;
 	pixel_y = 0
 	},
@@ -16241,7 +16241,7 @@
 /obj/machinery/button/alternate/door{
 	desc = "A remote control-switch for the office door.";
 	id_tag = "csodoor";
-	name = "CSO's Office Door Control";
+	name = "HoR's Office Door Control";
 	pixel_x = 28;
 	pixel_y = 28;
 	req_access = list("ACCESS_RESEARCH_DIRECTOR")
@@ -16534,7 +16534,7 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
 /obj/machinery/photocopier/faxmachine{
-	department = "Chief Medical Officer's Office - Torch"
+	department = "Head of Medical"
 	},
 /obj/item/weapon/stamp/cmo,
 /obj/item/device/radio{
@@ -16808,9 +16808,9 @@
 /obj/effect/floor_decal/corner/red/mono,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
-	department = "Chief of Security's Desk";
+	department = "Head of Security's Desk";
 	departmentType = 5;
-	name = "Chief of Security RC";
+	name = "Head of Security RC";
 	pixel_x = 32;
 	pixel_y = 0
 	},
@@ -18617,9 +18617,9 @@
 /obj/item/weapon/folder/white,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
-	department = "Chief Science Officer's Desk";
+	department = "Head of Research's Desk";
 	departmentType = 5;
-	name = "Chief Science Officer RC";
+	name = "Head of Research RC";
 	pixel_x = 0;
 	pixel_y = 30
 	},
@@ -18825,7 +18825,7 @@
 "Wi" = (
 /obj/structure/table/glass,
 /obj/machinery/photocopier/faxmachine{
-	department = "Chief Science Officer's Office - Torch"
+	department = "Head of Research - Dagon"
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -19017,7 +19017,7 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/door/airlock/medical{
 	id_tag = "cmodoor";
-	name = "Chief Medical Officer";
+	name = "Head of Medical";
 	secured_wires = 1
 	},
 /obj/machinery/door/firedoor,
@@ -19438,7 +19438,7 @@
 	},
 /obj/effect/floor_decal/corner/yellow/mono,
 /obj/machinery/photocopier/faxmachine{
-	department = "CE"
+	department = "Head of Engineering"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -449,7 +449,7 @@
 
 /area/shuttle/petrov/rd
 	icon_state = "heads_rd"
-	name = "\improper NTRL Polyp - CSO's Office"
+	name = "\improper NTRL Polyp - HoR's Office"
 	icon_state = "head_quarters"
 	req_access = list(access_petrov_rd)
 
@@ -535,10 +535,10 @@
 	icon_state = "shuttle3"
 	base_turf = /turf/simulated/open
 
-/area/turbolift/robotics_lift	
-	name = "\improper Robotics Lift"	
-	icon_state = "shuttle3"	
-	base_turf = /turf/simulated/open	
+/area/turbolift/robotics_lift
+	name = "\improper Robotics Lift"
+	icon_state = "shuttle3"
+	base_turf = /turf/simulated/open
 
 //Merchant
 
@@ -650,22 +650,22 @@
 
 /area/crew_quarters/heads/office/rd
 	icon_state = "heads_rd"
-	name = "\improper Command - CSO's Office"
+	name = "\improper Command - HoR's Office"
 	req_access = list(access_rd)
 
 /area/crew_quarters/heads/office/cmo
 	icon_state = "heads_cmo"
-	name = "\improper Command - CMO's Office"
+	name = "\improper Command - HoM's Office"
 	req_access = list(access_cmo)
 
 /area/crew_quarters/heads/office/ce
 	icon_state = "heads_ce"
-	name = "\improper Engineering - CE's Office"
+	name = "\improper Engineering - HoE's Office"
 	req_access = list(access_ce)
 
 /area/crew_quarters/heads/office/cos
 	icon_state = "heads_hos"
-	name = "\improper Command - CoS' Office"
+	name = "\improper Command - HoS' Office"
 	req_access = list(access_hos)
 
 /area/crew_quarters/heads/office/cl
@@ -1494,7 +1494,7 @@
 	name = "\improper Robotics Lab"
 	icon_state = "robotics"
 
-/area/assembly/robotics/lower	
+/area/assembly/robotics/lower
 	name = "\improper Lower Robotics Lab"
 
 /area/assembly/robotics/surgery


### PR DESCRIPTION
This PR changes their titles from Chief to Head along with any objects they might carry and their offices.

The reason for this change is primarily uniformity, the CoS and CE currently run into issues where they are sometimes confused by their senior enlisted counterpart. The 'Chief' title also prevents E7+ Fleeties from being properly called by their rank by MilRPers without being confused for a head of staff. 

I am leaving this for people vote and maintainers to judge and i'm not going to waste my breath replying to anyone as I will answer every question you might have.

- **Why?** Because I'd like it if SNCO Fleet RPers get the chance to feel validated by their ranks without being confused for a head of staff and for heads of staff to be properly called by their ranks.
- **It's not broke** Yes it is, ask any CoS/BC player for the biggest examples.
- **This impacts my character** I honestly cannot see how the change in the title impacts your character. Your rank is remaining the same and your duties remain the same. 
- **Some of these have stupid meme abbreviations** Yeah well I gave people the option of telling me if they want Head of Department or Department Officer in Charge and most people opted for Heads.
- **This is a stupid and pointless change** Maybe but the whole of the server is letting people enjoy the game and a lot of MilRPers hate being mistaken for heads of staff or heads of staff hate being mistaken for chiefs. Chiefs and Officers have two very different duties and I know some MilRPers would feel a lot better if they're properly addressed.
- **You're shoving this down our throats for your stupid MilRP** No, i'm making a change that will help non-MilRPers recognize that the structure of Mil ranks isn't so simple and that to the people who enjoy MilRP, the rank/role hold meaning and give a certain sense of validation. If I wanted to really shove this down your throat you'd be getting OICs or better yet removing the HoS and replacing it with an SNCO.
- **Why are they all Head of Department? Why can't the CMO or CE keep their titles that were grandfathered in?** The main reason is uniformity. The titles before were all uniform and I wish to keep them uniform.

I can't think of any other question that could possibly be asked but if someone actually asks a non-meme question that I can answer, i'll be keeping an eye on the comments. Otherwise, please thumbsup/thumbsdown and convince the maintainers, not me.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->