### PR TITLE
Allows suit sensors to be set on spawn & See IPC charge on suit sensors console.

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -482,6 +482,13 @@ SUBSYSTEM_DEF(jobs)
 		job.equip(H, H.mind ? H.mind.role_alt_title : "", H.char_branch, H.char_rank)
 		job.apply_fingerprints(H)
 		spawn_in_storage = equip_custom_loadout(H, job)
+
+		var/obj/item/clothing/under/uniform = H.w_uniform
+		if(istype(uniform) && uniform.has_sensor)
+			uniform.sensor_mode = H.client.prefs.sensor_setting
+			if(H.client.prefs.sensors_locked)
+				uniform.has_sensor = SUIT_LOCKED_SENSORS
+
 	else
 		to_chat(H, "Your job is [rank] and the game just can't handle it! Please report this bug to an administrator.")
 

--- a/code/datums/repositories/crew/binary.dm
+++ b/code/datums/repositories/crew/binary.dm
@@ -9,6 +9,10 @@
 				crew_data["alert"] = TRUE
 		if(H.get_blood_oxygenation() < BLOOD_VOLUME_SAFE)
 			crew_data["alert"] = TRUE
+	if(H.isSynthetic())
+		var/obj/item/organ/internal/cell/cell = H.internal_organs_by_name[BP_CELL]
+		if(!cell || cell.percent() < 10)
+			crew_data["alert"] = TRUE
 	return ..()
 
 /* Jamming */

--- a/code/datums/repositories/crew/vital.dm
+++ b/code/datums/repositories/crew/vital.dm
@@ -21,6 +21,19 @@
 					crew_data["pulse_span"] = "average"
 				if(PULSE_THREADY)
 					crew_data["pulse_span"] = "bad"
+	crew_data["charge"] = "N/A"
+	crew_data["charge_span"] = "N/A"
+	if(H.isSynthetic())
+		var/obj/item/organ/internal/cell/cell = H.internal_organs_by_name[BP_CELL]
+		if(cell)
+			crew_data["charge"] = cell.percent()
+			if(cell.percent() <= 10)
+				crew_data["charge_span"] = "bad"
+			else
+				crew_data["charge_span"] = "good"
+		else
+			crew_data["charge"] = "No cell"
+			crew_data["charge_span"] = "bad"
 
 	crew_data["pressure"] = "N/A"
 	crew_data["true_oxygenation"] = -1
@@ -55,6 +68,11 @@
 		crew_data["true_pulse"] = PULSE_NORM
 		crew_data["pulse"] = rand(60, 90)
 		crew_data["pulse_span"] = "good"
+	
+	if(isnum(crew_data["charge"]))
+		crew_data["charge"] = rand(10,66)
+		crew_data["charge_span"] = "good"
+
 
 	if(crew_data["true_oxygenation"] != -1)
 		crew_data["pressure"] = "[Floor(120+rand(-5,5))]/[Floor(80+rand(-5,5))]"
@@ -68,6 +86,10 @@
 		crew_data["true_pulse"] = PULSE_NONE
 		crew_data["pulse"] = 0
 		crew_data["pulse_span"] = "bad"
+	
+	if(isnum(crew_data["charge"]))
+		crew_data["charge"] = 0
+		crew_data["charge_span"] = "bad"
 
 	if(crew_data["true_oxygenation"] != -1)
 		crew_data["pressure"] = "[Floor((120+rand(-5,5))*0.25)]/[Floor((80+rand(-5,5))*0.25)]"

--- a/code/modules/client/preference_setup/general/03_equipment.dm
+++ b/code/modules/client/preference_setup/general/03_equipment.dm
@@ -5,11 +5,15 @@
 	var/decl/backpack_outfit/backpack
 	var/list/backpack_metadata
 
+	var/sensor_setting
+	var/sensors_locked
+
 /datum/category_item/player_setup_item/physical/equipment
 	name = "Clothing"
 	sort_order = 3
 
 	var/static/list/backpacks_by_name
+	var/list/sensorModes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
 
 /datum/category_item/player_setup_item/physical/equipment/New()
 	..()
@@ -27,7 +31,8 @@
 	from_file(S["all_underwear_metadata"], pref.all_underwear_metadata)
 	from_file(S["backpack"], load_backbag)
 	from_file(S["backpack_metadata"], pref.backpack_metadata)
-
+	from_file(S["sensor_setting"], pref.sensor_setting)
+	from_file(S["sensors_locked"], pref.sensors_locked)
 	pref.backpack = backpacks_by_name[load_backbag] || get_default_outfit_backpack()
 
 /datum/category_item/player_setup_item/physical/equipment/save_character(var/savefile/S)
@@ -35,6 +40,8 @@
 	to_file(S["all_underwear_metadata"], pref.all_underwear_metadata)
 	to_file(S["backpack"], pref.backpack.name)
 	to_file(S["backpack_metadata"], pref.backpack_metadata)
+	to_file(S["sensor_setting"], pref.sensor_setting)
+	to_file(S["sensors_locked"], pref.sensors_locked)
 
 /datum/category_item/player_setup_item/physical/equipment/sanitize_character()
 	if(!istype(pref.all_underwear))
@@ -85,6 +92,11 @@
 				var/list/metadata = tweak_metadata["[tweak]"]
 				tweak_metadata["[tweak]"] = tweak.validate_metadata(metadata)
 
+	if(isnull(pref.sensor_setting))
+		pref.sensor_setting = SUIT_SENSOR_OFF
+
+	if(isnull(pref.sensors_locked))
+		pref.sensors_locked = FALSE
 
 /datum/category_item/player_setup_item/physical/equipment/content()
 	. = list()
@@ -103,6 +115,8 @@
 	for(var/datum/backpack_tweak/bt in pref.backpack.tweaks)
 		. += " <a href='?src=\ref[src];backpack=[pref.backpack.name];tweak=\ref[bt]'>[bt.get_ui_content(get_backpack_metadata(pref.backpack, bt))]</a>"
 	. += "<br>"
+	. += "Default Suit Sensor Setting: <a href='?src=\ref[src];change_sensor_setting=1'>[sensorModes[pref.sensor_setting + 1]]</a><br />"
+	. += "Suit Sensors Locked: <a href='?src=\ref[src];toggle_sensors_locked=1'>[pref.sensors_locked ? "Locked" : "Unlocked"]</a><br />"
 	return jointext(.,null)
 
 /datum/category_item/player_setup_item/physical/equipment/proc/get_underwear_metadata(var/underwear_category, var/datum/gear_tweak/gt)
@@ -174,7 +188,13 @@
 		if(new_metadata)
 			set_backpack_metadata(bo, bt, new_metadata)
 			return TOPIC_REFRESH_UPDATE_PREVIEW
-
+	else if(href_list["change_sensor_setting"])
+		var/switchMode = input("Select a sensor mode:", "Suit Sensor Mode", sensorModes[pref.sensor_setting + 1]) in sensorModes
+		pref.sensor_setting = sensorModes.Find(switchMode) - 1
+		return TOPIC_REFRESH
+	else if(href_list["toggle_sensors_locked"])
+		pref.sensors_locked = !pref.sensors_locked
+		return TOPIC_REFRESH
 	return ..()
 
 /datum/category_item/player_setup_item/physical/equipment/update_setup(var/savefile/preferences, var/savefile/character)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -786,7 +786,7 @@ BLIND     // can't see anything
 	w_class = ITEM_SIZE_NORMAL
 	force = 0
 	var/has_sensor = SUIT_HAS_SENSORS //For the crew computer 2 = unable to change mode
-	var/sensor_mode = 0
+	var/sensor_mode = SUIT_SENSOR_OFF
 		/*
 		1 = Report living/dead
 		2 = Report detailed damages
@@ -925,13 +925,13 @@ BLIND     // can't see anything
 /obj/item/clothing/under/examine(mob/user)
 	. = ..()
 	switch(src.sensor_mode)
-		if(0)
+		if(0)			if(SUIT_SENSOR_OFF)
 			to_chat(user, "Its sensors appear to be disabled.")
-		if(1)
+		if(1)			if(SUIT_SENSOR_BINARY)
 			to_chat(user, "Its binary life sensors appear to be enabled.")
-		if(2)
+		if(2)			if(SUIT_SENSOR_VITAL)
 			to_chat(user, "Its vital tracker appears to be enabled.")
-		if(3)
+		if(3)			if(SUIT_SENSOR_TRACKING)
 			to_chat(user, "Its vital tracker and tracking beacon appear to be enabled.")
 
 /obj/item/clothing/under/proc/set_sensors(mob/user as mob)
@@ -954,17 +954,17 @@ BLIND     // can't see anything
 
 	if (src.loc == user)
 		switch(sensor_mode)
-			if(0)
+			if(SUIT_SENSOR_OFF)
 				user.visible_message("[user] adjusts the tracking sensor on \his [src.name].", "You disable your suit's remote sensing equipment.")
-			if(1)
+			if(SUIT_SENSOR_BINARY)
 				user.visible_message("[user] adjusts the tracking sensor on \his [src.name].", "Your suit will now report whether you are live or dead.")
-			if(2)
+			if(SUIT_SENSOR_VITAL)
 				user.visible_message("[user] adjusts the tracking sensor on \his [src.name].", "Your suit will now report your vital lifesigns.")
-			if(3)
+			if(SUIT_SENSOR_TRACKING)
 				user.visible_message("[user] adjusts the tracking sensor on \his [src.name].", "Your suit will now report your vital lifesigns as well as your coordinate position.")
 
 	else if (ismob(src.loc))
-		if(sensor_mode == 0)
+		if(sensor_mode == SUIT_SENSOR_OFF)
 			user.visible_message("<span class='warning'>[user] disables [src.loc]'s remote sensing equipment.</span>", "You disable [src.loc]'s remote sensing equipment.")
 		else
 			user.visible_message("[user] adjusts the tracking sensor on [src.loc]'s [src.name].", "You adjust [src.loc]'s sensors.")

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -257,7 +257,7 @@
 	if(isSynthetic())
 		var/obj/item/organ/internal/cell/C = internal_organs_by_name[BP_CELL]
 		if(istype(C))
-			if(!C.is_usable())
+			if(!C.is_usable() || !C.percent())
 				return TRUE
 	else if(should_have_organ(BP_HEART))
 		var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -69,6 +69,11 @@
 			var/mob/living/carbon/human/H = M
 			to_chat(user, "<span class='notice'>Analyzing Results for \the [H]:</span>")
 			to_chat(user, "Key: <font color='#ffa500'>Electronics</font>/<font color='red'>Brute</font>")
+			var/obj/item/organ/internal/cell/C = H.internal_organs_by_name[BP_CELL]
+			if(C)
+				to_chat(user, SPAN_NOTICE("Cell charge: [C.percent()] %"))
+			else
+				to_chat(user, SPAN_NOTICE("Cell charge: ERROR - Cell not present"))
 			to_chat(user, "<span class='notice'>External prosthetics:</span>")
 			var/organ_found
 			for(var/obj/item/organ/external/E in H.organs)

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -21,10 +21,16 @@ Used In File(s): code\modules\modular_computers\file_system\programs\medical\sui
 			<td>{{:value.name}} ({{:value.assignment}}): </td>
 
 			{{if value.sensor_type >= 2}}
-				{{if value.true_pulse == -1}}
-					<td><span class="white">Pulse</span> <span class='{{:value.pulse_span}}'>{{:value.pulse}}</span></td>
+				{{if value.pulse != "N/A"}}
+					{{if value.true_pulse == -1}}
+						<td><span class="white">Pulse</span> <span class='{{:value.pulse_span}}'>{{:value.pulse}}</span></td>
+					{{else}}
+						<td><span class="white">Pulse</span> <span class='{{:value.pulse_span}}'>{{:value.pulse}}</span> bpm</td>
+					{{/if}}
+				{{else value.charge_span != "N/A"}}
+					<td><span class="white">Charge</span> <span class='{{:value.charge_span}}'>{{:value.charge}}%</span></td>
 				{{else}}
-					<td><span class="white">Pulse</span> <span class='{{:value.pulse_span}}'>{{:value.pulse}}</span> bpm</td>
+					<td><span class="white">Pulse</span> <span class="white">N/A</span></td>
 				{{/if}}
 			{{else}}
 				{{if value.alert}}


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Does exactly what it says on the title. Credits go to mikomyazaki and mustafakalash.
:cl: Mikomyazaki, Mustafakalash.
tweak: Suit Sensors program will now report cell charge for synthetic crew-members.
tweak: Robot analyzers will report cell charge of the target synthetic.
rscadd: You can now set a default suit sensor setting and locked state from character setup
/:cl: