### PR TITLE
Gives the robotics vendor some more stuff.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1209,10 +1209,11 @@
 	req_access = list(access_robotics)
 	base_type = /obj/machinery/vending/robotics
 	products = list(/obj/item/weapon/reagent_containers/food/drinks/bottle/oiljug = 5,
-					/obj/item/stack/cable_coil = 4,/obj/item/device/flash/synthetic = 4,/obj/item/weapon/cell = 4,/obj/item/device/scanner/health = 2,
+					/obj/item/stack/cable_coil = 4,/obj/item/device/flash/synthetic = 4,/obj/item/weapon/cell = 4,/obj/item/device/scanner/health = 3,
 					/obj/item/weapon/scalpel = 1,/obj/item/weapon/circular_saw = 1,/obj/item/weapon/tank/anesthetic = 2,/obj/item/clothing/mask/breath/medical = 5,
-					/obj/item/weapon/screwdriver = 2,/obj/item/weapon/crowbar = 2)
+					/obj/item/weapon/screwdriver = 2, /obj/item/device/robotanalyzer = 3, /obj/item/weapon/crowbar = 2)
 	contraband = list(/obj/item/device/flash = 2)
+	premium = list(/obj/item/weapon/weldingtool/largetank = 2)
 
 //FOR ACTORS GUILD - mainly props that cannot be spawned otherwise
 /obj/machinery/vending/props


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
This PR gives the robotics vendor one more health analyzer and three spare robotic analyzers. Also two welding tools on the premium section.
:cl: Vhbraz
tweak: Robotics vendor now has spare robotic analyzers & welders.
/:cl: