### PR TITLE
Item Stack Improvements

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -32,6 +32,13 @@
 	if (amount >= 1)
 		src.amount = amount
 	..()
+	if(isturf(loc))
+		spawn(0)
+			for(var/obj/item/stack/S in loc)
+				if(S == src)
+					continue
+				if(S.stacktype == stacktype)
+					transfer_to(S)
 
 /obj/item/stack/Initialize()
 	. = ..()
@@ -306,6 +313,12 @@
 	. = ..()
 	if (amount < max_amount)
 		. = ceil(. * amount / max_amount)
+
+/obj/item/stack/Crossed(obj/o)
+	if(istype(o, /obj/item/stack) && !o.throwing)
+		var/obj/item/stack/S = o
+		transfer_to(S)
+	. = ..()
 
 /obj/item/stack/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -316,7 +316,7 @@
 
 /obj/item/stack/Crossed(obj/o)
 	spawn(0)
-		if(loc == o.loc && istype(o, /obj/item/stack) && !o.throwing)
+		if(isturf(loc) && loc == o.loc && istype(o, /obj/item/stack) && !o.throwing)
 			var/obj/item/stack/S = o
 			transfer_to(S)
 	. = ..()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -32,18 +32,18 @@
 	if (amount >= 1)
 		src.amount = amount
 	..()
-	if(isturf(loc))
+
+/obj/item/stack/Initialize(mapload)
+	. = ..()
+	if(!plural_name)
+		plural_name = "[singular_name]s"
+	if(isturf(loc) && !mapload)
 		spawn(0)
 			for(var/obj/item/stack/S in loc)
 				if(S == src)
 					continue
 				if(S.stacktype == stacktype)
 					transfer_to(S)
-
-/obj/item/stack/Initialize()
-	. = ..()
-	if(!plural_name)
-		plural_name = "[singular_name]s"
 
 /obj/item/stack/Destroy()
 	if(uses_charge)
@@ -315,9 +315,10 @@
 		. = ceil(. * amount / max_amount)
 
 /obj/item/stack/Crossed(obj/o)
-	if(istype(o, /obj/item/stack) && !o.throwing)
-		var/obj/item/stack/S = o
-		transfer_to(S)
+	spawn(0)
+		if(loc == o.loc && istype(o, /obj/item/stack) && !o.throwing)
+			var/obj/item/stack/S = o
+			transfer_to(S)
 	. = ..()
 
 /obj/item/stack/attack_hand(mob/user as mob)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -121,7 +121,7 @@
 		visible_message("<span class='warning'>\The [src] shatters!</span>")
 
 	var/debris_count = is_fulltile() ? 4 : 1
-	for(var/i = 0 to debris_count)
+	for(var/i = 1 to debris_count)
 		material.place_shard(loc)
 		if(reinf_material)
 			new /obj/item/stack/material/rods(loc, 1, reinf_material.name)

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -139,11 +139,12 @@
 
 	to_chat(user, "<span class='notice'>You reinforce the [target_stack] with the [reinf_mat.display_name].</span>")
 	used_stack.use(1)
+	var/target_loc = target_stack.loc
 	var/obj/item/stack/material/S = target_stack.split(needed_sheets)
 	S.reinf_material = reinf_mat
 	S.update_strings()
 	S.update_icon()
-	S.dropInto(target_stack.loc)
+	S.dropInto(target_loc)
 
 /material/proc/build_wired_product(var/mob/user, var/obj/item/stack/used_stack, var/obj/item/stack/target_stack)
 	if(!wire_product)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -36,7 +36,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 26 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
-exactly 501 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 502 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 broken_files=0

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -36,7 +36,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 26 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
-exactly 500 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 501 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 broken_files=0


### PR DESCRIPTION
Have you ever wanted to fix a bug and then you accidentally turn it into a dozen other bugfixes and improvements? Yeah. It happened again.

Fixed a bug where reinforcing the last sheet of glass in a stack with rods didn't yield anything.
Fixed a duplication bug where breaking a window gave you 1 extra glass shard and rod.
Made it so that stacks stack with other stacks when stacked by a stack of the same stacktype through means of movement or when initialized. You can drag stacks to gather them up, and they'll automatically stack when they spawn in.