### PR TITLE
Adds Cooling Units to Shell IPC loadouts

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/xenowear_boh.dm
+++ b/code/modules/client/preference_setup/loadout/lists/xenowear_boh.dm
@@ -3,5 +3,5 @@
 	display_name = "cooling unit (IPC)"
 	path = /obj/item/device/suit_cooling_unit
 	sort_category = "Xenowear"
-	whitelisted = list(SPECIES_IPC)
+	whitelisted = list(SPECIES_IPC, SPECIES_SHELL)
 	cost = 0


### PR DESCRIPTION
What it says on the tin.

Shell IPCs can now select cooling units in their loadout like regular IPCs