### PR TITLE
Infantry Prep changes based on feedback

### DIFF
--- a/maps/torch/structures/closets.dm
+++ b/maps/torch/structures/closets.dm
@@ -97,7 +97,7 @@
 		/obj/item/weapon/storage/belt/holster/security/tactical,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/weapon/material/knife/combat,
-		/obj/item/weapon/storage/box/flares,
+		/obj/item/weapon/storage/box/illumnades,
 		/obj/item/gunbox/inftech,
 		/obj/item/clothing/suit/armor/pcarrier/medium/sol
 		)
@@ -125,7 +125,6 @@
 		/obj/item/weapon/storage/belt/holster/security/tactical,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/weapon/material/knife/combat,
-		/obj/item/weapon/storage/firstaid/combat,
 		/obj/item/solbanner,
 		/obj/item/clothing/suit/armor/pcarrier/medium/sol,
 		/obj/item/gunbox/infcom,

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -3208,7 +3208,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/photocopier,
+/obj/item/sticky_pad/random{
+	pixel_x = -9;
+	pixel_y = -2
+	},
+/obj/item/weapon/folder/blue{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/structure/table/woodentable/walnut,
 /turf/simulated/floor/tiled/dark,
 /area/infantry)
 "fP" = (
@@ -3659,7 +3667,10 @@
 /area/quartermaster/expedition/eva)
 "gG" = (
 /obj/structure/catwalk,
-/obj/machinery/suit_cycler/infantry,
+/obj/structure/bed/roller/ironingboard,
+/obj/item/weapon/ironingiron{
+	pixel_y = -4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "gH" = (
@@ -3721,7 +3732,6 @@
 /area/quartermaster/expedition/atmos)
 "gN" = (
 /obj/structure/disposalpipe/segment,
-/obj/random/tool,
 /obj/random/mre,
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -3737,6 +3747,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/weapon/reagent_containers/food/condiment/small/packet/crayon/purple,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "gO" = (
@@ -3761,12 +3772,6 @@
 "gQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/rack/shelf/steel,
-/obj/item/seeds/random{
-	pixel_x = -6
-	},
-/obj/item/seeds/random{
-	pixel_x = 7
-	},
 /obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3775,6 +3780,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/seeds/finetobaccoseed,
+/obj/item/seeds/finetobaccoseed,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "gR" = (
@@ -11676,6 +11683,11 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
+/obj/machinery/recharger/wallcharger{
+	dir = 8;
+	pixel_x = 23;
+	pixel_y = -3
+	},
 /turf/simulated/floor/tiled/dark,
 /area/infantry/inftech)
 "vA" = (
@@ -12223,7 +12235,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/storage/box/illumnades,
 /turf/simulated/floor/tiled/dark,
 /area/infantry/inftech)
 "xN" = (
@@ -14182,7 +14193,6 @@
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
 "Fm" = (
-/obj/structure/table/steel,
 /obj/item/weapon/paper_bin{
 	pixel_x = -5;
 	pixel_y = 10
@@ -14198,10 +14208,7 @@
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 4
 	},
-/obj/machinery/chemical_dispenser/tac_coffee/full/good{
-	pixel_x = -7;
-	pixel_y = -10
-	},
+/obj/structure/table/woodentable/walnut,
 /turf/simulated/floor/tiled/dark,
 /area/infantry)
 "Fn" = (
@@ -14362,7 +14369,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "Gf" = (
-/obj/structure/table/steel,
 /obj/item/weapon/deck/cards{
 	pixel_x = -5;
 	pixel_y = 5
@@ -14378,6 +14384,7 @@
 	pixel_x = -22;
 	pixel_y = 3
 	},
+/obj/structure/table/woodentable/walnut,
 /turf/simulated/floor/wood/walnut,
 /area/infantry)
 "Gh" = (
@@ -14509,7 +14516,7 @@
 /obj/effect/floor_decal/carpet/blue2{
 	dir = 9
 	},
-/obj/structure/table/steel,
+/obj/structure/table/woodentable/walnut,
 /turf/simulated/floor/wood/walnut,
 /area/infantry)
 "GG" = (
@@ -14825,7 +14832,6 @@
 	pixel_x = -2
 	},
 /obj/item/weapon/storage/belt/utility/full{
-	pixel_x = -5;
 	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -15135,6 +15141,11 @@
 	},
 /obj/item/rig_module/grenade_launcher/light,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/recharger/wallcharger{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = -3
+	},
 /turf/simulated/floor/tiled/dark,
 /area/infantry/infcom)
 "Jf" = (
@@ -15243,13 +15254,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/analysis)
-"Jy" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/crowbar,
-/obj/item/weapon/wrench,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
-/area/infantry)
 "Jz" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -16468,7 +16472,6 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/isolation)
 "Ok" = (
-/obj/structure/table/steel,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -16485,6 +16488,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/table/woodentable/walnut,
 /turf/simulated/floor/tiled/dark,
 /area/infantry)
 "Oq" = (
@@ -16596,14 +16600,8 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/petrov/rnd)
 "OP" = (
-/obj/structure/table/rack/shelf/steel,
 /obj/structure/catwalk,
-/obj/item/stack/material/steel/fifty{
-	pixel_x = -6
-	},
-/obj/item/stack/material/plasteel/ten{
-	pixel_x = 7
-	},
+/obj/machinery/suit_cycler/infantry,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "OU" = (
@@ -16760,17 +16758,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "PF" = (
-/obj/structure/table/steel,
-/obj/item/weapon/folder/blue{
-	pixel_x = 2;
-	pixel_y = 4
-	},
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 4
-	},
-/obj/item/sticky_pad/random{
-	pixel_x = -9;
-	pixel_y = -2
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16779,6 +16768,16 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/chemical_dispenser/tac_coffee/full/good{
+	density = 0;
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG{
+	pixel_x = -9;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/infantry)
@@ -17015,7 +17014,6 @@
 /turf/simulated/floor/lino,
 /area/shuttle/petrov/rd)
 "QI" = (
-/obj/structure/table/steel,
 /obj/effect/floor_decal/carpet/blue2{
 	icon_state = "blue2"
 	},
@@ -17026,7 +17024,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/recharger,
+/obj/structure/table/woodentable/walnut,
 /turf/simulated/floor/wood/walnut,
 /area/infantry)
 "QJ" = (
@@ -17225,12 +17223,21 @@
 /area/shuttle/petrov/cell2)
 "RM" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/crowbar,
-/obj/item/weapon/wrench,
+/obj/item/weapon/crowbar{
+	pixel_y = 3
+	},
+/obj/item/weapon/wrench{
+	pixel_x = 1
+	},
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light/spot{
 	dir = 4
+	},
+/obj/machinery/recharger/wallcharger{
+	dir = 8;
+	pixel_x = 23;
+	pixel_y = -3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/infantry)
@@ -17451,15 +17458,17 @@
 /area/quartermaster/expedition/atmos)
 "SG" = (
 /obj/structure/closet/crate/freezer,
-/obj/item/weapon/reagent_containers/food/drinks/cans/cola,
-/obj/item/weapon/reagent_containers/food/drinks/cans/cola,
-/obj/item/weapon/reagent_containers/food/drinks/cans/cola,
-/obj/item/weapon/reagent_containers/food/drinks/cans/cola,
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/pizzabox/meat,
+/obj/item/weapon/reagent_containers/food/drinks/cans/beastenergy,
+/obj/item/weapon/reagent_containers/food/drinks/cans/beastenergy,
+/obj/item/weapon/reagent_containers/food/drinks/cans/iced_tea,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/space_mountain_wind,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/gingerbeer,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/space_up,
+/obj/item/weapon/reagent_containers/food/drinks/cans/cola,
 /turf/simulated/floor/wood/walnut,
 /area/infantry)
 "SH" = (
@@ -17641,10 +17650,10 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "Tp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/infantry)
 "Ts" = (
@@ -17872,12 +17881,10 @@
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/bicaridine,
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/kelotane,
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline,
-/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline,
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/pain,
-/obj/item/modular_computer/tablet/lease{
-	pixel_x = 2
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/detox,
+/obj/item/modular_computer/tablet/lease/preset/command,
 /turf/simulated/floor/tiled/dark,
 /area/infantry/infcom)
 "Um" = (
@@ -18658,7 +18665,7 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/obj/item/weapon/storage/box/frags{
+/obj/item/weapon/storage/box/fragshells{
 	pixel_y = 2
 	},
 /turf/simulated/floor/tiled/dark,
@@ -18969,7 +18976,6 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/hallwaya)
 "YY" = (
-/obj/structure/table/steel,
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
@@ -18979,6 +18985,7 @@
 /obj/effect/floor_decal/carpet/blue2{
 	dir = 1
 	},
+/obj/structure/table/woodentable/walnut,
 /turf/simulated/floor/wood/walnut,
 /area/infantry)
 "YZ" = (
@@ -19113,8 +19120,12 @@
 /area/shuttle/petrov/hallwaya)
 "Zs" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/crowbar,
-/obj/item/weapon/wrench,
+/obj/item/weapon/crowbar{
+	pixel_y = 3
+	},
+/obj/item/weapon/wrench{
+	pixel_x = 1
+	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/recharger/wallcharger{
 	dir = 8;
@@ -32090,7 +32101,7 @@ ZG
 ZG
 zA
 XS
-Jy
+Zs
 Zs
 RM
 yV


### PR DESCRIPTION
Makes the infantry prep prettier
:cl: OolongCow
maptweak: adds chargers for every role
maptweak: removes the single table charger
maptweak: wooden tables replace the metal ones
maptweak: moved stuff on the squad lead desk around
maptweak: replaces the random seeds with fine tobacco seeds
maptweak: replaces the shelf with extra materials with an ironing board and iron
tweak: fixes the broken squad lead tablet
tweak: removes the combat medkit from the sl's locker as intended
tweak: replaces the secured box of grenades with a box of grenades for underslung grenade launchers
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->