### PR TITLE
Infantry Gun Registration Resets

### DIFF
--- a/maps/torch/infantry/firearms.dm
+++ b/maps/torch/infantry/firearms.dm
@@ -151,7 +151,7 @@
 	name = "P10 pistol"
 	desc = "The Hephaestus Industries P10 - a mass produced kinetic sidearm in widespread service with the SCGDF. It has a slide restrictor, preventing quick-draw type shooting."
 	fire_delay = 12
-	req_access = list(access_hop)
+	req_access = list(access_infantry)
 	authorized_modes = list(UNAUTHORIZED)
 	firemodes = list(
 		list(mode_name="fire", burst=1, fire_delay=null, move_delay=null, one_hand_penalty=2, burst_accuracy=null, dispersion=null),
@@ -172,7 +172,7 @@
 	starts_loaded = 1
 	one_hand_penalty = 6 //lower power rounds
 	jam_chance = 5
-	req_access = list(access_hop)
+	req_access = list(access_infantry)
 	authorized_modes = list(UNAUTHORIZED)
 	firemodes = list(
 		list(mode_name="semi auto",       burst=1,    fire_delay=null,    move_delay=null, use_launcher=null, one_hand_penalty=8, burst_accuracy=null, dispersion=null),
@@ -211,7 +211,7 @@
 /obj/item/weapon/gun/projectile/shotgun/pump/combat/infantry
 	desc = "Built for close quarters combat, the Hephaestus Industries KS-40 is widely regarded as a weapon of choice for repelling boarders. \
 	It appears to have a firing restrictor installed, to prevent firing without authorization aboard the Dagon."
-	req_access = list(access_hop)
+	req_access = list(access_infantry)
 	authorized_modes = list(UNAUTHORIZED)
 
 /////////
@@ -224,7 +224,7 @@
 	charge_cost = 10
 	max_shots = 20
 	fire_delay = 10
-	req_access = list(access_hop)
+	req_access = list(access_infantry)
 	authorized_modes = list(UNAUTHORIZED)
 	firemodes = list(
 		list(mode_name="fire", burst=1, fire_delay=null, move_delay=null, one_hand_penalty=4, burst_accuracy=null, dispersion=null),
@@ -238,7 +238,7 @@
 	name = "L7 SAW"
 	desc = "A rather traditionally made L7 SAW with a pleasantly lacquered wooden pistol grip. Has 'Aussec Armoury- 2561' engraved on the reciever. \
 	It appears to have a firing restrictor installed, to prevent firing without authorization aboard the Dagon."
-	req_access = list(access_hop)
+	req_access = list(access_infantry)
 	authorized_modes = list(UNAUTHORIZED)
 	firemodes = list(
 		list(mode_name="semi auto", burst=1, fire_delay=null, move_delay=null, one_hand_penalty=6, burst_accuracy=null, dispersion=null),
@@ -301,7 +301,7 @@
 	max_shells = 8
 	ammo_type = /obj/item/ammo_casing/sabot
 	caliber = CALIBER_SABOT
-	req_access = list(access_hop)
+	req_access = list(access_infantry)
 	authorized_modes = list(UNAUTHORIZED)
 	jam_chance = 25 //big ol' gun. Purely for balance.
 	base_parry_chance = 20


### PR DESCRIPTION
ayyy I fixed it

:cl: OolongCow
tweak: changes access_hop to access_infantry needed to reset infantry weapons, copying the way security's weapons are coded
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->