### PR TITLE
Fits flashlights on webbed vests

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -209,7 +209,7 @@
 		bomb = ARMOR_BOMB_PADDED
 		)
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
-	allowed = list(/obj/item/weapon/gun/energy,/obj/item/device/radio,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/weapon/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/gun/magnetic)
+	allowed = list(/obj/item/weapon/gun/energy,/obj/item/device/radio,/obj/item/device/flashlight,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/weapon/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/gun/magnetic)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	cold_protection = UPPER_TORSO|LOWER_TORSO
@@ -360,7 +360,7 @@
 /obj/item/clothing/suit/armor/pcarrier/tan/ipc
 	name = "compact tan plate carrier"
 	desc = "A modular, compact tan plate carrier vest made to securely fit an IPC chassis. It doesn't look like it would fit an organic. It can be equipped with armor plates, but provides no protection of its own."
-	icon_state = "pcarrier_tan_ipc"	
+	icon_state = "pcarrier_tan_ipc"
 	species_restricted = list(SPECIES_IPC)
 
 /obj/item/clothing/suit/armor/pcarrier/tan/tactical


### PR DESCRIPTION
Webbed armor vests can now take flashlights and derivatives.