### PR TITLE
Fixes Shell IPC equipment

### DIFF
--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -14,7 +14,7 @@
 		rad = ARMOR_RAD_SMALL
 		)
 	siemens_coefficient = 0.3
-	species_restricted = list(SPECIES_HUMAN,SPECIES_IPC)
+	species_restricted = list(SPECIES_HUMAN,SPECIES_IPC,SPECIES_SHELL)
 	camera = /obj/machinery/camera/network/mercenary
 	light_overlay = "helmet_light_green" //todo: species-specific light overlays
 
@@ -38,7 +38,7 @@
 		)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs)
 	siemens_coefficient = 0.3
-	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_IPC)
+	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_IPC,SPECIES_SHELL)
 
 /obj/item/clothing/suit/space/void/merc/New()
 	..()

--- a/code/modules/species/station/shell.dm
+++ b/code/modules/species/station/shell.dm
@@ -85,6 +85,9 @@
 	brute_mod =      1.2
 	burn_mod =       1.6
 
+/datum/species/shell/get_bodytype(var/mob/living/carbon/human/H)
+	return SPECIES_HUMAN
+
 /datum/species/shell/handle_death(var/mob/living/carbon/human/H)
 	..()
 	if(istype(H.wear_mask,/obj/item/clothing/mask/monitor))


### PR DESCRIPTION
Expanding upon my WIP shell race, shells are now given the human bodytype, meaning they have the same clothing and clothing restrictions as humans do.

You can now wear voidsuits and rigs again, oorah.