### PR TITLE
Removes Exchange Role. Minor map tweaks.

### DIFF
--- a/maps/away/skrellscoutship/skrellscoutship-1.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship-1.dmm
@@ -2928,11 +2928,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
-"CZ" = (
-/obj/structure/curtain/open/bed,
-/obj/structure/bed/padded,
-/turf/simulated/floor/tiled/skrell/orange,
-/area/ship/skrellscoutship/crew/quarters)
 "Dj" = (
 /obj/effect/paint/black,
 /turf/simulated/wall/r_wall,
@@ -2985,7 +2980,6 @@
 "FA" = (
 /obj/structure/curtain/open/bed,
 /obj/structure/bed/padded,
-/obj/effect/submap_landmark/spawnpoint/skrellscoutship/infantry,
 /obj/effect/submap_landmark/spawnpoint/skrellscoutship/infantry,
 /obj/effect/submap_landmark/spawnpoint/skrellscoutship/infantry,
 /turf/simulated/floor/tiled/skrell/orange,
@@ -10825,7 +10819,7 @@ vZ
 BW
 gX
 FA
-CZ
+FA
 NN
 vZ
 en

--- a/maps/away/skrellscoutship/skrellscoutship-1.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship-1.dmm
@@ -43,29 +43,20 @@
 	output_level = 200000
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/ship/skrellscoutship/maintenance/power)
 "al" = (
-/obj/machinery/power/smes/buildable/preset/skrell{
-	charge = 5e+006;
-	input_attempt = 1;
-	input_level = 200000;
-	output_attempt = 1;
-	output_level = 200000
+/obj/machinery/power/terminal{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced,
 /area/ship/skrellscoutship/maintenance/power)
 "am" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -89,15 +80,19 @@
 /turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/toilets)
 "ap" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/alarm/skrell{
 	dir = 2;
 	pixel_x = 0;
 	pixel_y = 32
+	},
+/obj/machinery/telecomms/allinone/skrellscoutship,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/skrellscoutship/maintenance/power)
@@ -432,21 +427,11 @@
 /turf/simulated/floor/reinforced,
 /area/ship/skrellscoutship/maintenance/power)
 "bu" = (
+/obj/machinery/power/shield_generator,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/telecomms/allinone/skrellscoutship,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/critical{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24;
-	req_access = list("ACCESS_SKRELLSCOUT")
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/skrellscoutship/maintenance/power)
@@ -523,6 +508,11 @@
 /area/ship/skrellscoutship/crew/kitchen)
 "bG" = (
 /obj/structure/window/phoronreinforced,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/reinforced,
 /area/ship/skrellscoutship/maintenance/power)
 "bI" = (
@@ -659,9 +649,15 @@
 	dir = 8
 	},
 /obj/structure/window/phoronreinforced,
-/obj/machinery/light{
+/obj/machinery/power/apc/critical{
 	dir = 8;
-	icon_state = "tube1"
+	name = "west bump";
+	pixel_x = -24;
+	req_access = list("ACCESS_SKRELLSCOUT")
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/skrellscoutship/maintenance/power)
@@ -695,13 +691,18 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/power/shield_generator,
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/window/phoronreinforced,
-/turf/simulated/floor/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/paint/black,
+/turf/simulated/wall/r_wall,
 /area/ship/skrellscoutship/maintenance/power)
 "ce" = (
 /obj/structure/table/glass,
@@ -1596,38 +1597,12 @@
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/command/armory)
 "ee" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/toilets)
 "eg" = (
-/obj/structure/table/rack,
-/obj/item/weapon/tank/skrell,
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 8;
-	name = "Command RIG";
-	req_access = list("ACCESS_SKRELLSCOUT")
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/weapon/rig/skrell/exchange,
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/command/armory)
+/obj/machinery/light,
+/turf/simulated/floor/tiled/skrell/white,
+/area/ship/skrellscoutship/crew/toilets)
 "en" = (
 /obj/machinery/light{
 	dir = 4;
@@ -2187,18 +2162,17 @@
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
 "kC" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/reinforced,
 /area/ship/skrellscoutship/maintenance/power)
 "le" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -2447,14 +2421,14 @@
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/crew/brig)
 "qD" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
 /area/ship/skrellscoutship/maintenance/power)
 "qE" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
@@ -2562,6 +2536,18 @@
 	},
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
+"tq" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/skrellscoutship/maintenance/power)
 "tL" = (
 /obj/machinery/button/blast_door{
 	id_tag = "skcell1_window";
@@ -2688,27 +2674,13 @@
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/command/armory)
 "wx" = (
-/obj/machinery/power/smes/buildable/preset/skrell{
-	charge = 5e+006;
-	input_attempt = 1;
-	input_level = 200000;
-	output_attempt = 1;
-	output_level = 200000
-	},
+/obj/effect/paint/black,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/ship/skrellscoutship/maintenance/power)
 "wR" = (
 /obj/machinery/alarm/skrell{
@@ -2862,6 +2834,19 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/reinforced,
 /area/ship/skrellscoutship/maintenance/atmos)
+"AC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/skrellscoutship/maintenance/power)
 "AD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -2919,6 +2904,14 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
+"BD" = (
+/obj/machinery/door/blast/shutters{
+	dir = 4;
+	id_tag = "xil_xield";
+	name = "Shields Containment"
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/skrellscoutship/maintenance/power)
 "BL" = (
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
@@ -2938,7 +2931,6 @@
 "CZ" = (
 /obj/structure/curtain/open/bed,
 /obj/structure/bed/padded,
-/obj/effect/submap_landmark/spawnpoint/skrellscoutship/exchange,
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/crew/quarters)
 "Dj" = (
@@ -2993,6 +2985,7 @@
 "FA" = (
 /obj/structure/curtain/open/bed,
 /obj/structure/bed/padded,
+/obj/effect/submap_landmark/spawnpoint/skrellscoutship/infantry,
 /obj/effect/submap_landmark/spawnpoint/skrellscoutship/infantry,
 /obj/effect/submap_landmark/spawnpoint/skrellscoutship/infantry,
 /turf/simulated/floor/tiled/skrell/orange,
@@ -3237,7 +3230,6 @@
 	dir = 9;
 	pixel_y = 0
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/toilets)
 "MP" = (
@@ -3315,6 +3307,21 @@
 	},
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/crew/quarters)
+"Qn" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/power/smes/buildable/preset/skrell{
+	charge = 5e+006;
+	input_attempt = 1;
+	input_level = 200000;
+	output_attempt = 1;
+	output_level = 200000
+	},
+/turf/simulated/floor/plating,
+/area/ship/skrellscoutship/maintenance/power)
 "Rk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
@@ -3374,6 +3381,15 @@
 	},
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/command/armory)
+"RX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/paint/black,
+/turf/simulated/wall/r_wall,
+/area/ship/skrellscoutship/maintenance/power)
 "Sb" = (
 /obj/machinery/light{
 	dir = 4;
@@ -3429,6 +3445,23 @@
 "TE" = (
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
+"TJ" = (
+/obj/structure/window/phoronreinforced,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "xil_xield";
+	name = "Shield Containment";
+	pixel_x = 27;
+	pixel_y = 5;
+	req_access = list("ACCESS_SKRELLSCOUT")
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/skrellscoutship/maintenance/power)
 "TL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -3542,6 +3575,14 @@
 	},
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/crew/brig)
+"VD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/skrellscoutship/maintenance/power)
 "VH" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -10801,7 +10842,7 @@ Sb
 df
 Xb
 xD
-eg
+dA
 ex
 aF
 dA
@@ -11027,7 +11068,7 @@ aa
 aR
 an
 oP
-aR
+ee
 bS
 bS
 bS
@@ -11148,8 +11189,8 @@ aa
 aa
 aR
 Wz
-ee
-aR
+oP
+eg
 bS
 cz
 cz
@@ -11271,7 +11312,7 @@ aa
 aR
 an
 oP
-aR
+ee
 bS
 cz
 bq
@@ -11393,14 +11434,14 @@ aa
 aR
 mu
 oP
-aR
+ee
 bS
 cz
 cz
 cz
 aJ
 cq
-cz
+VD
 cT
 UB
 UB
@@ -11515,7 +11556,7 @@ aa
 aR
 mu
 oP
-aR
+ee
 bS
 aq
 aq
@@ -11637,14 +11678,14 @@ aa
 aR
 XV
 MM
-aR
+eg
 bS
 ap
 VH
-VH
-VH
+AC
+tq
 br
-bG
+TJ
 dI
 UB
 UB
@@ -11759,14 +11800,14 @@ aa
 aR
 xu
 Gr
-aR
+ee
 bS
 kC
+cq
 qD
-qD
-qD
-cz
-bG
+bS
+BD
+RX
 mb
 UB
 UB
@@ -11885,7 +11926,7 @@ aR
 bS
 ak
 al
-al
+Qn
 wx
 bu
 cc

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -44,10 +44,6 @@
 	name = "Mekerr-Ketish"
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
-/obj/effect/submap_landmark/spawnpoint/skrellscoutship/exchange
-	name = "Exchange Qrii-Zuumqix"
-	movable_flags = MOVABLE_FLAG_EFFECTMOVE
-
 /obj/effect/submap_landmark/spawnpoint/skrellscoutship/leader
 	name = "Qrri-Vuxix"
 
@@ -58,7 +54,6 @@
 	descriptor = "Skrellian Scout Ship"
 	map = "Xilvuxix"
 	crew_jobs = list(
-		/datum/job/submap/skrellscoutship_crew/exchange,
 		/datum/job/submap/skrellscoutship_crew/engineer,
 		/datum/job/submap/skrellscoutship_crew/medical,
 		/datum/job/submap/skrellscoutship_crew/infantry,
@@ -104,38 +99,6 @@
 /datum/job/submap/skrellscoutship_crew/get_description_blurb()
 	return "You are an engineer and/or a demolitions specialist for your crew. You are responsible for repairing damage to your SSV aswell as providing engineering support in the field. You answer directly to your Qrii'Vuxix"
 //Real jobs start here
-
-/datum/job/submap/skrellscoutship_crew/exchange
-	title = "Exchange Qrii-Zuumqix"
-	supervisors = "your Qrri-Vuxix"
-	total_positions = 1
-	selection_color = "#656565"
-	whitelisted_species = list(SPECIES_HUMAN, SPECIES_VATGROWN, SPECIES_SPACER, SPECIES_GRAVWORLDER, SPECIES_TRITONIAN, SPECIES_BOOSTER)
-	blacklisted_species = list(SPECIES_SKRELL)
-	outfit_type = /decl/hierarchy/outfit/job/skrellscoutship/exchange
-	info = "Your vessel is scouting through unknown space, working to map out any potential dangers, as well as potential allies. Your STDF has given you a implant that allows you to understand and speak skrellian."
-	branch = /datum/mil_branch/skrell_fleet
-	rank = /datum/mil_rank/skrell_fleet
-	allowed_branches = list(/datum/mil_branch/skrell_fleet)
-	allowed_ranks = list(/datum/mil_rank/skrell_fleet/zuumqix)
-	skill_points = 30
-	is_semi_antagonist = TRUE
-	min_skill = list(SKILL_EVA 			= SKILL_ADEPT,
-					SKILL_HAULING 		= SKILL_ADEPT,
-					SKILL_COMBAT 		= SKILL_BASIC,
-					SKILL_WEAPONS 		= SKILL_BASIC,
-					SKILL_MEDICAL 		= SKILL_BASIC)
-	max_skill = list(SKILL_CONSTRUCTION = SKILL_EXPERT,
-					SKILL_ELECTRICAL   = SKILL_EXPERT,
-					SKILL_ATMOS        = SKILL_EXPERT,
-					SKILL_ENGINES      = SKILL_EXPERT,
-					SKILL_EVA          = SKILL_EXPERT,
-					SKILL_HAULING      = SKILL_EXPERT,
-					SKILL_WEAPONS	   = SKILL_EXPERT,
-					SKILL_COMBAT	   = SKILL_EXPERT
-					)
-/datum/job/submap/skrellscoutship_crew/exchange/get_description_blurb()
-	return "You are a human on a cultural exchange program aboard a skrellian recon vessel. You answer to the Qrii'Vuxix."
 
 /datum/job/submap/skrellscoutship_crew/engineer
 	title = "Xiqarr-Ketish"
@@ -205,7 +168,7 @@
 /datum/job/submap/skrellscoutship_crew/infantry
 	title = "Mekerr-Ketish"
 	supervisors = "your Qrri-Vuxix"
-	total_positions = 2
+	total_positions = 4
 	selection_color = "#601c1c"
 	alt_titles = list(
 		"Qixoal-Ketish",


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Vhbraz
tweak: Removes the Exchange Qrii-Zuumqix role.
maptweak: Changes the layout of the SMES room a bit on the SSV.
/:cl: