### PR TITLE
Remove Limb Printing from Bioprinters

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -113,14 +113,14 @@
 		BP_EYES     = list(/obj/item/organ/internal/eyes,       20),
 		BP_LIVER    = list(/obj/item/organ/internal/liver,      25),
 		BP_STOMACH  = list(/obj/item/organ/internal/stomach,    25),
-		BP_L_ARM    = list(/obj/item/organ/external/arm,        65),
-		BP_R_ARM    = list(/obj/item/organ/external/arm/right,  65),
-		BP_L_LEG    = list(/obj/item/organ/external/leg,        65),
-		BP_R_LEG    = list(/obj/item/organ/external/leg/right,  65),
-		BP_L_FOOT   = list(/obj/item/organ/external/foot,       40),
-		BP_R_FOOT   = list(/obj/item/organ/external/foot/right, 40),
-		BP_L_HAND   = list(/obj/item/organ/external/hand,       40),
-		BP_R_HAND   = list(/obj/item/organ/external/hand/right, 40),
+	//	BP_L_ARM    = list(/obj/item/organ/external/arm,        65), //Commented out. No more free organic limbs. Prosthetics gang.
+	//	BP_R_ARM    = list(/obj/item/organ/external/arm/right,  65),
+	//	BP_L_LEG    = list(/obj/item/organ/external/leg,        65),
+	//	BP_R_LEG    = list(/obj/item/organ/external/leg/right,  65),
+	//	BP_L_FOOT   = list(/obj/item/organ/external/foot,       40),
+	//	BP_R_FOOT   = list(/obj/item/organ/external/foot/right, 40),
+	//	BP_L_HAND   = list(/obj/item/organ/external/hand,       40),
+	//	BP_R_HAND   = list(/obj/item/organ/external/hand/right, 40),
 		BP_CELL		= list(/obj/item/organ/internal/cell, 25)
 		)
 

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -113,14 +113,6 @@
 		BP_EYES     = list(/obj/item/organ/internal/eyes,       20),
 		BP_LIVER    = list(/obj/item/organ/internal/liver,      25),
 		BP_STOMACH  = list(/obj/item/organ/internal/stomach,    25),
-	//	BP_L_ARM    = list(/obj/item/organ/external/arm,        65), //Commented out. No more free organic limbs. Prosthetics gang.
-	//	BP_R_ARM    = list(/obj/item/organ/external/arm/right,  65),
-	//	BP_L_LEG    = list(/obj/item/organ/external/leg,        65),
-	//	BP_R_LEG    = list(/obj/item/organ/external/leg/right,  65),
-	//	BP_L_FOOT   = list(/obj/item/organ/external/foot,       40),
-	//	BP_R_FOOT   = list(/obj/item/organ/external/foot/right, 40),
-	//	BP_L_HAND   = list(/obj/item/organ/external/hand,       40),
-	//	BP_R_HAND   = list(/obj/item/organ/external/hand/right, 40),
 		BP_CELL		= list(/obj/item/organ/internal/cell, 25)
 		)
 


### PR DESCRIPTION
Your votes are in. 

Bioprinters can no longer print organic limbs. They are still able to make organs, however limb replacements are now all prosthetics from robotics.

No longer will people need to wonder why anyone has prosthetics in a world where we can print limbs like paper.

