### PR TITLE
Temporarely disables dnaswitch anomaly.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3176,7 +3176,6 @@
 #include "code\modules\xenoarcheaology\effects\cellcharge.dm"
 #include "code\modules\xenoarcheaology\effects\celldrain.dm"
 #include "code\modules\xenoarcheaology\effects\cold.dm"
-#include "code\modules\xenoarcheaology\effects\dnaswitch.dm"
 #include "code\modules\xenoarcheaology\effects\emp.dm"
 #include "code\modules\xenoarcheaology\effects\forcefield.dm"
 #include "code\modules\xenoarcheaology\effects\gasco2.dm"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
This temporarely disabled the xenoarcheology DNAswitch anomalies.
Plan is to keep them off-round until I eventually get around to making them curable or making them not affect genemods.
:cl: Vhbraz
rscdel: DNAswitch anomalies will not spawn anymore.
/:cl: