### PR TITLE
MC fix 1.0

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -206,7 +206,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 #else
 	world.sleep_offline = TRUE
 #endif
-	world.TgsInitializationComplete()
+	world.TgsInitializationComplete()		//Gives it back. Was it supposed to die? @r4iser
 	world.fps = config.fps
 	var/initialized_tod = REALTIMEOFDAY
 
@@ -233,14 +233,15 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	var/rtn = Loop()
 	if (rtn > 0 || processing < 0)
 		return //this was suppose to happen.
-	//loop ended, restart the mc
-	log_game("MC crashed or runtimed, restarting")
-	message_admins("MC crashed or runtimed, restarting")
-	var/rtn2 = Recreate_MC()
-	if (rtn2 <= 0)
-		log_game("Failed to recreate MC (Error code: [rtn2]), it's up to the failsafe now")
-		message_admins("Failed to recreate MC (Error code: [rtn2]), it's up to the failsafe now")
-		Failsafe.defcon = 2
+	//loop ended, restart the mc		//That it was supposed to so \/
+	else			//If that return was taking no effect, the crash wont be happening
+		log_game("MC crashed or runtimed, restarting")
+		message_admins("MC crashed or runtimed, restarting")
+		var/rtn2 = Recreate_MC()
+		if (rtn2 <= 0)
+			log_game("Failed to recreate MC (Error code: [rtn2]), it's up to the failsafe now")
+			message_admins("Failed to recreate MC (Error code: [rtn2]), it's up to the failsafe now")
+			Failsafe.defcon = 2
 
 // Main loop.
 /datum/controller/master/proc/Loop()


### PR DESCRIPTION
Makes sure that the line 234 condition will be happening, that should say that theres still hardware to process it.

Adds back world.TgsInitializationComplete().
Looks like it shouldnt be removed. Treats for when the server is initializing. Could even break a restart to save the MC.

###
Tested intensively on my localhost. I could hit crazy process levels without having the MC to crash.
The code was not handling how it was supposed to do when to call or not the crash, apparently.

Returns may gets tricky on byond, so I've put the MC crash things into an else, if the game is good to go, it will keep going.
###

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->