### PR TITLE
By sigmar you have posted CRINGE(Prommies are no longer immortal)

### DIFF
--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -224,7 +224,13 @@
 		H.adjust_nutrition(3)
 		return 1
 
-	if(innate_heal && (H.getBruteLoss() + H.getFireLoss() > 10) && !(H.stat == UNCONSCIOUS))
+	if(H.nutrition < 40 && innate_heal && (H.getBruteLoss() + H.getFireLoss() > 10))
+		if(H.should_have_organ(BP_SLIMECORE))
+			var/obj/item/organ/internal/brain/slime/sponge = H.internal_organs_by_name[BP_SLIMECORE]
+			if(sponge)
+				sponge.take_internal_damage(1)
+
+	if(H.nutrition < 10 && innate_heal)
 		if(H.should_have_organ(BP_SLIMECORE))
 			var/obj/item/organ/internal/brain/slime/sponge = H.internal_organs_by_name[BP_SLIMECORE]
 			if(sponge)

--- a/code/modules/species/station/prometheans.dm
+++ b/code/modules/species/station/prometheans.dm
@@ -38,7 +38,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	burn_mod =            1.1
 	toxins_mod =          0.1
 	oxy_mod =             0
-	total_health =        275
+	total_health =        250
 	siemens_coefficient = -1
 	rarity_value =        5
 	slowdown = 0.5

--- a/code/modules/species/station/prometheans.dm
+++ b/code/modules/species/station/prometheans.dm
@@ -38,7 +38,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	burn_mod =            1.1
 	toxins_mod =          0.1
 	oxy_mod =             0
-	total_health =        250
+	total_health =        275
 	siemens_coefficient = -1
 	rarity_value =        5
 	slowdown = 0.5

--- a/code/modules/species/station/prometheans.dm
+++ b/code/modules/species/station/prometheans.dm
@@ -38,7 +38,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	burn_mod =            1.1
 	toxins_mod =          0.1
 	oxy_mod =             0
-	total_health =        150
+	total_health =        275
 	siemens_coefficient = -1
 	rarity_value =        5
 	slowdown = 0.5

--- a/code/modules/species/station/prometheans.dm
+++ b/code/modules/species/station/prometheans.dm
@@ -38,7 +38,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	burn_mod =            1.1
 	toxins_mod =          0.1
 	oxy_mod =             0
-	total_health =        275
+	total_health =        220
 	siemens_coefficient = -1
 	rarity_value =        5
 	slowdown = 0.5


### PR DESCRIPTION
Before prommies did not take braindamage while asleep, allowing them to regen infinitely. Bruh.
Also makes them require nutriment to sustain their healing (before it was free)
:honk:
🆑 Yawet330
codetweak: Prommies now have 20 more brainHP than humans, at the cost of functoning like Unathi with their braindamage. This means prommies now A) Take massive amounts of braindamage, very, very quickly when out of hunger
/🆑