### PR TITLE
Paint gun can paint light tubes/bulbs

### DIFF
--- a/code/game/objects/items/devices/paint_gun.dm
+++ b/code/game/objects/items/devices/paint_gun.dm
@@ -127,6 +127,12 @@
 			D.stripe_airlock(paint_colour)
 		return
 
+	var/obj/item/weapon/light/L = A
+	if(istype(L))
+		L.b_colour = paint_colour
+		L.on_update_icon()
+		return
+
 	var/turf/simulated/floor/F = A
 	if(!istype(F) || !F.flooring)
 		to_chat(user, "<span class='warning'>\The [src] can only be used on floors, walls or certain airlocks.</span>")


### PR DESCRIPTION
Ooooh, colored lighting. Hit a light tube/bulb (not fixture) with a paint gun to change its color.

![image](https://user-images.githubusercontent.com/11510380/99460153-a5fdaf80-292f-11eb-8223-13632428fbe2.png)