### PR TITLE
Lets humans pick the spacecop faction

### DIFF
--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -148,6 +148,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 			FACTION_FLEET,
 			FACTION_MARINES,
 			FACTION_PCRC,
+			FACTION_SPACECOPS,
 			FACTION_OTHER
 		),
 		TAG_CULTURE = list(


### PR DESCRIPTION
Why the fuck are the factions humans can pick under /datum/map instead of /datum/species/human like all other species?

I don't know, but I ran it locally and solfed police now shows up as faction for humans. 