### PR TITLE
Properly disables limb printing from Bioprinters

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -247,7 +247,8 @@
 	for(var/organ in loaded_species.has_organ)
 		organs += loaded_species.has_organ[organ]
 	for(var/organ in loaded_species.has_limbs)
-		organs += loaded_species.has_limbs[organ]["path"]
+		if ((loaded_species.name == SPECIES_NABBER) || (organ == BP_GROIN))
+			organs += loaded_species.has_limbs[organ]["path"]
 	for(var/organ in organs)
 		var/obj/item/organ/O = organ
 		if(check_printable(organ))


### PR DESCRIPTION
Bioprinters can no longer print limbs for any species aside from GAS, since GAS can't have prosthetics.

We voted for the change before, and prosthetics won by a landslide. This PR finally tweaks it.