### PR TITLE
Pilot Suit Cycler Update Deck 5 Dagon

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -5749,7 +5749,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
 "kv" = (
-/obj/machinery/suit_cycler/pilot,
+/obj/machinery/suit_cycler/pilot{
+	req_access = list("ACCESS_CAPTAIN","ACCESS_BRIDGE","ACCESS_TORCH_PILOT")
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4


### PR DESCRIPTION
Updates the pilot suit cycler in exploration suit prep so that the shuttle pilots can use it. Before, only the captain and bridge officer's had access.