### PR TITLE
Clean up on Zeng-Hu chassis

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -84,14 +84,12 @@ var/datum/robolimb/basic_robolimb
 	can_eat = 1
 	unavailable_at_fab = 1
 	allowed_bodytypes = list(SPECIES_HUMAN,SPECIES_SHELL)
-	species_cannot_use = list()
 
-/datum/robolimb/zenghu/spirit
+/datum/robolimb/spirit
 	company = "Zeng-Hu Spirit"
 	desc = "This limb has a sleek black and white polymer finish."
 	icon = 'icons/mob/human_races/cyberlimbs/zenghu/zenghu_spirit.dmi'
 	unavailable_at_fab = 1
-	allowed_bodytypes = list(SPECIES_HUMAN)
 
 /datum/robolimb/xion
 	company = "Xion"


### PR DESCRIPTION
Did a weird oopsie, apparently Zeng-Hu Spirit is a sub of Zeng-Hu

Separated them, IPCs should be able to select the correct body again.