### PR TITLE
Duffels can now hold huge items

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -188,13 +188,14 @@
 	icon_state = "duffle"
 	item_state_slots = null
 	w_class = ITEM_SIZE_HUGE
-	max_storage_space = DEFAULT_BACKPACK_STORAGE + 10
+	max_w_class = ITEM_SIZE_HUGE
+	max_storage_space = DEFAULT_BACKPACK_STORAGE + 20
 
 /obj/item/weapon/storage/backpack/dufflebag/New()
 	..()
-	slowdown_per_slot[slot_back] = 3
-	slowdown_per_slot[slot_r_hand] = 1
-	slowdown_per_slot[slot_l_hand] = 1
+	slowdown_per_slot[slot_back] = 6
+	slowdown_per_slot[slot_r_hand] = 4
+	slowdown_per_slot[slot_l_hand] = 4
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie
 	name = "black dufflebag"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -187,7 +187,7 @@
 	desc = "A large dufflebag for holding extra things."
 	icon_state = "duffle"
 	item_state_slots = null
-	w_class = ITEM_SIZE_HUGE
+	w_class = ITEM_SIZE_GARGANTUAN
 	max_w_class = ITEM_SIZE_HUGE
 	max_storage_space = DEFAULT_BACKPACK_STORAGE + 20
 


### PR DESCRIPTION
### **What was changed exactly?**

- Duffels can now hold items of size HUGE (backpacks and guns and only up to 3 combined).
- Duffels are now bigger (size GARGANTUAN). 
- Duffels are now heavier (wearing one is on par with wearing a heavy hardsuit).

### **Why?** 

- Tactful placement of gear. Its impossible to stealthily move larger gear like guns which encourages antags to go loud the moment they buy anything more serious than a pistol.

- This opens a door to what i call "gear kits". In the future we can have certain antags like terrorists buy set gear packs allowing us to control their difficulty and giving them a solid basis to make their plans on, for example Heavy, medic, stealth, etc kits.

- This also opens a opportunity for supportive roles to do much more, such as ammo carrier or just holding a large amount of medical supplies and items you never could before.
 

- It promotes a emphasis on preparation. Instead of buying/obtaining and rushing (especially in the case of antagonists), a person is now encouraged to stockpile needed gear and place it tactfully while planning carefully.

### **Concerns.** 

- Isn't  putting backpacks in duffels really OP? Yes and no, this will allow people to store gear in a tarkov way but it will not serve to be a combat advantage unless you leave someone long enough to pull out a backpack from their duffel and in turn pull a item from the backpack and then, especially if it needs two hands, to return the backpack. This change will not really affect how combat works in that sense.

- Won't this allow guns stacking during combat? Yes it will, but at a cost. Duffels can hold guns but guns are still very very large and you will still be insanely slow, especially if you stack this with heavy armour. If you put in a single AR for example, it'll leave you with a bit more space than a normal backpack (this might seem off, yes you could fit a gun in a normal backpack BUT you cant because HUGE is restricted from normal backpacks). If you wear heavy armour with a duffel it'll make you slower than wearing a unpowered heavy armour hardsuit.

- How is this logical, how can i put a backpack in a duffel! You actually can, go try it, but that's one huge duffel.