### PR TITLE
Psi ADV Changes

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -816,7 +816,7 @@
 	description = "A rare and expensive drug used legally by professionals to awaken psionic latencies in those who possess them, dangerous in higher doses."
 	reagent_state = LIQUID
 	color = "#d0ff00"
-	metabolism = 1
+	metabolism = REM * 0.5
 	overdose = 5
 
 	var/global/list/dose_messages = list(

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -131,7 +131,7 @@
 		"Foundation Agent")
 
 /datum/job/psiadvisor/equip(var/mob/living/carbon/human/H)
-	psi_faculties = list("[PSI_REDACTION]" = PSI_RANK_OPERANT, "[PSI_COERCION]" = PSI_RANK_OPERANT, "[PSI_PSYCHOKINESIS]" = PSI_RANK_OPERANT, "[PSI_ENERGISTICS]" = PSI_RANK_OPERANT)
+	psi_faculties = list("[PSI_REDACTION]" = PSI_RANK_LATENT, "[PSI_COERCION]" = PSI_RANK_LATENT, "[PSI_PSYCHOKINESIS]" = PSI_RANK_LATENT, "[PSI_ENERGISTICS]" = PSI_RANK_LATENT)
 	return ..()
 
 /datum/job/psiadvisor/get_description_blurb()

--- a/maps/torch/job/outfits/boh_outfits.dm
+++ b/maps/torch/job/outfits/boh_outfits.dm
@@ -172,12 +172,14 @@
 /decl/hierarchy/outfit/job/torch/crew/command/psiadvisor/equip_id(var/mob/living/carbon/human/H, var/rank, var/assignment, var/equip_adjustments)
 	. = ..()
 	var/obj/item/weapon/card/id/foundation_civilian/regis_card = new
+	var/obj/item/weapon/reagent_containers/pill/jerraman/psipill = new
 	if(rank)
 		regis_card.rank = rank
 	if(assignment)
 		regis_card.assignment = assignment
 	H.set_id_info(regis_card)
 	H.equip_to_slot_or_store_or_drop(regis_card)
+	H.equip_to_slot_or_store_or_drop(psipill)
 
 /decl/hierarchy/outfit/job/torch/crew/representative
 	name = OUTFIT_JOB_NAME("SolGov Representative")


### PR DESCRIPTION
Makes psi advisors be able to 'randomise' their statistics roundstart as suggested. Gives them a pill and latencies by default.

Edit: Also fixes Jerraman just not working at times due to the way metabolism works. hate.

🆑 Yawet330
codetweak: Psi advisors now have latent in all categories, and spawn with a jerraman pill to awaken it
codetweak: Jerraman is now slightly less cringe, and has a proper metabolism calculation
/🆑