### PR TITLE
Civilian Dogtags are now generic

### DIFF
--- a/maps/torch/items/clothing/boh_accessory.dm
+++ b/maps/torch/items/clothing/boh_accessory.dm
@@ -30,7 +30,7 @@
 
 // Dog Tags badge string rename, plus added for SMC and NTEF.
 /obj/item/clothing/accessory/badge/solgov/tags
-	badge_string = "NTSS Dagon"
+	badge_string = ""
 
 /obj/item/clothing/accessory/badge/solgov/tags/fleet
 	badge_string = "NTEF"


### PR DESCRIPTION
Change being made for RP reasons, so that offship roles no longer have "NTSS Dagon" stamped on their tags.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->