### PR TITLE
Adds several negatives traits back to genemodder

### DIFF
--- a/modular_mithra/code/modules/mithra/traits_neutral.dm
+++ b/modular_mithra/code/modules/mithra/traits_neutral.dm
@@ -14,13 +14,13 @@
 /datum/trait/cold_blooded
 	name = "Ectothermy"
 	desc = "You have diminished means of internal thermoregulation, forcing you to rely on external heat to stay alive."
-	var_changes = list("body_temperature" = 285, "cold_discomfort_level" = 292)
+	var_changes = list("body_temperature" = 280,15, "cold_discomfort_level" = 279,15)
 	excludes = list(/datum/trait/hot_blooded)
 
 /datum/trait/hot_blooded
 	name = "Hot-blooded"
 	desc = "Your body is capable of more vigourous endothermoregulation, causing your average body temperature to be higher than normal."
-	var_changes = list("body_temperature" = 313, "heat_discomfort_level" = 320)
+	var_changes = list("body_temperature" = 319,15 "heat_discomfort_level" = 316)
 	excludes = list(/datum/trait/cold_blooded)
 
 /datum/trait/nitrogen_breath
@@ -59,3 +59,91 @@
 		..(S,H)
 		for(var/u_type in S.unarmed_types)
 			S.unarmed_attacks += new u_type()
+
+/datum/trait/speed_slow
+	name = "Sluggish"
+	desc = "You move slower than the average person."
+	var_changes = list("slowdown" = 1.5)
+
+/datum/trait/endurance_low
+	name = "Fragile"
+	desc = "Your body is much, much more fragile than the average joe."
+	var_changes = list("total_health" = 65)
+
+	apply(var/datum/species/S,var/mob/living/carbon/human/H)
+		..(S,H)
+		H.setMaxHealth(S.total_health)
+
+
+/datum/trait/minor_brute_weak
+	name = "Thin Skin"
+	desc = "Your skin is thinner than normal, making you slightly more susceptible to physical damage."
+	var_changes = list("brute_mod" = 1.50)
+
+/datum/trait/minor_burn_weak
+	name = "Inflammable Skin"
+	desc = "You skin is somehow inflammable, making you slightly more susceptible to burns."
+	var_changes = list("burn_mod" = 1.50)
+
+/datum/trait/conductive
+	name = "Conductive Skin"
+	desc = "Your skin has a lower electrical resistivity than normal, making you much more conductive."
+	var_changes = list("siemens_coefficient" = 1.5) //This makes you a lot weaker to tasers.
+
+
+/datum/trait/photosensitive
+	name = "Photosensitive"
+	desc = "Your eyes are especially sensitive to bright lights."
+	var_changes = list("flash_mod" = 2.0)
+
+/datum/trait/hollow
+	name = "Glass Bones"
+	desc = "Your limbs are just more fragile than usual for whatever reason, making them easier to break."
+
+/datum/trait/hollow/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	for(var/obj/item/organ/external/O in H.organs)
+		O.min_broken_damage *= 0.5
+
+/datum/trait/oxy_weak
+	name = "Haemoglobin Improbus"
+	desc = "You have a lower blood-oxygen saturation, meaning asphyxiation is a greater risk to you."
+	var_changes = list("oxy_mod" = 1.50)
+
+/datum/trait/toxin_weak
+	name = "Paper Liver"
+	desc = "Your metabolism isn't very good at processing toxins, making poisons more effective against you."
+	var_changes = list("toxins_mod" = 1.50)
+
+/datum/trait/noodlyarms
+	name = "Muscular Atrophy"
+	desc = "You have less muscle mass than normal, giving you inferior strength."
+	var_changes = list("strength" = STR_LOW)
+
+/////////////////////
+// BoH Materials
+/////////////////////
+
+/datum/trait/toxification_junky
+	name = "Weak Immune System"
+	desc = "Your immune system is incredibly weak, and even the slightest ailment may kill you. Be sure to notify Doctors not to overdose you!"
+	var_changes = list("toxins_mod" = 5.0)
+
+/datum/trait/hemophilia
+	name = "Hemophilia"
+	desc = "Your body doesn't quite stop bleeding once it starts. You need immediate treatment for anything, even minor wounds, or it might turn out real bad for you."
+	var_changes = list("blood_volume" = 105) //The bare minimum before it becomes critical.
+
+/datum/trait/stick_human
+	name = "Incredibly Frail"
+	desc = "Your bones, skin and general state of mind is rather fragile. Try not to get smacked, or you may have to visit the ER."
+	var_changes = list("brute_mod" =2.50)
+
+	/datum/trait/commune
+	name = "Telepathy"
+	desc = "Quite simply, you've the ability to project thoughts into the minds of others. A weak psychic manifestation too minor to require action from the local authorities, unlikely to ever develop into something greater."
+/datum/trait/commune/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/carbon/human/proc/psychic_whisper
+
+

--- a/modular_mithra/code/modules/mithra/traits_neutral.dm
+++ b/modular_mithra/code/modules/mithra/traits_neutral.dm
@@ -155,5 +155,4 @@
 /datum/trait/stick_human
 	name = "Incredibly Frail"
 	desc = "Your bones, skin and general state of mind is rather fragile. Try not to get smacked, or you may have to visit the ER."
-	var_changes = list("brute_mod" =2.50)
-
+	var_changes = list("brute_mod" = 2.50)

--- a/modular_mithra/code/modules/mithra/traits_neutral.dm
+++ b/modular_mithra/code/modules/mithra/traits_neutral.dm
@@ -14,14 +14,27 @@
 /datum/trait/cold_blooded
 	name = "Ectothermy"
 	desc = "You have diminished means of internal thermoregulation, forcing you to rely on external heat to stay alive."
-	var_changes = list("body_temperature" = 280,15, "cold_discomfort_level" = 279,15)
+	var_changes = list("cold_level_1" = 200,  "cold_level_2" = 150, "cold_level_3" = 90, "breath_cold_level_1" = 180, "breath_cold_level_2" = 100, "breath_cold_level_3" = 60, "cold_discomfort_level" = 210, "heat_level_1" = 305, "heat_level_2" = 360, "heat_level_3" = 700, "breath_heat_level_1" = 345, "breath_heat_level_2" = 380, "breath_heat_level_3" = 780, "heat_discomfort_level" = 295, "body_temperature" = 290)
 	excludes = list(/datum/trait/hot_blooded)
-
 /datum/trait/hot_blooded
 	name = "Hot-blooded"
 	desc = "Your body is capable of more vigourous endothermoregulation, causing your average body temperature to be higher than normal."
-	var_changes = list("body_temperature" = 319,15, "heat_discomfort_level" = 316)
+	var_changes = list("heat_level_1" = 420, "heat_level_2" = 460, "heat_level_3" = 1100, "breath_heat_level_1" = 440, "breath_heat_level_2" = 510, "breath_heat_level_3" = 1500, "heat_discomfort_level" = 390, "cold_level_1" = 280, "cold_level_2" = 220, "cold_level_3" = 140, "breath_cold_level_1" = 260, "breath_cold_level_2" = 240, "breath_cold_level_3" = 120, "cold_discomfort_level" = 280, "body_temperature" = 330)
 	excludes = list(/datum/trait/cold_blooded)
+
+
+	/datum/trait/autohiss_unathi
+	name = "Autohiss (Unathi)"
+	desc = "You roll your S's and x's"
+	var_changes = list(
+	autohiss_basic_map = list(
+			"s" = list("ss", "sss", "ssss")
+		),
+	autohiss_extra_map = list(
+			"x" = list("ks", "kss", "ksss")
+		),
+	autohiss_exempt = list("Sinta'unathi"))
+
 
 /datum/trait/nitrogen_breath
 	name = "Nitrogenous Spirometry"
@@ -40,6 +53,11 @@
 	var_changes = list("hunger_factor" = DEFAULT_HUNGER_FACTOR * 0.5, "metabolism_mod" = 0.5)
 	excludes = list(/datum/trait/fast_meta)
 
+/datum/trait/metabolism_apex
+	name = "Apex Metabolism"
+	desc = "Finally a proper excuse for your hungry actions. Essentially doubles the fast trait rates. Good for characters with big appetites."
+	var_changes = list("metabolic_rate" = 1.4, "hunger_factor" = 0.4, "metabolism" = 0.012) // +40% rate and 8x hunger
+	excludes = list(/datum/trait/slow_meta,/datum/trait/fast_meta)
 /datum/trait/carnivore
 	name = "Carnivore"
 	desc = "For one reason or another, you're only capable of eating meat. Vegetables won't kill you, but they won't help you either."

--- a/modular_mithra/code/modules/mithra/traits_neutral.dm
+++ b/modular_mithra/code/modules/mithra/traits_neutral.dm
@@ -20,7 +20,7 @@
 /datum/trait/hot_blooded
 	name = "Hot-blooded"
 	desc = "Your body is capable of more vigourous endothermoregulation, causing your average body temperature to be higher than normal."
-	var_changes = list("body_temperature" = 319,15 "heat_discomfort_level" = 316)
+	var_changes = list("body_temperature" = 319,15, "heat_discomfort_level" = 316)
 	excludes = list(/datum/trait/cold_blooded)
 
 /datum/trait/nitrogen_breath

--- a/modular_mithra/code/modules/mithra/traits_neutral.dm
+++ b/modular_mithra/code/modules/mithra/traits_neutral.dm
@@ -157,11 +157,3 @@
 	desc = "Your bones, skin and general state of mind is rather fragile. Try not to get smacked, or you may have to visit the ER."
 	var_changes = list("brute_mod" =2.50)
 
-	/datum/trait/commune
-	name = "Telepathy"
-	desc = "Quite simply, you've the ability to project thoughts into the minds of others. A weak psychic manifestation too minor to require action from the local authorities, unlikely to ever develop into something greater."
-/datum/trait/commune/apply(var/datum/species/S,var/mob/living/carbon/human/H)
-	..(S,H)
-	H.verbs |= /mob/living/carbon/human/proc/psychic_whisper
-
-

--- a/modular_mithra/code/modules/mithra/traits_neutral.dm
+++ b/modular_mithra/code/modules/mithra/traits_neutral.dm
@@ -86,7 +86,7 @@
 /datum/trait/endurance_low
 	name = "Fragile"
 	desc = "Your body is much, much more fragile than the average joe."
-	var_changes = list("total_health" = 65)
+	var_changes = list("total_health" = 115)
 
 	apply(var/datum/species/S,var/mob/living/carbon/human/H)
 		..(S,H)


### PR DESCRIPTION
Hello.
I am adding every negative trait back to genemodders.
Why you may ask...
Because only having 5 traits sucks.
And only negatives ones to the FBP genemoders don't power-game again.
The only positive trait i added back was telepathy, wich is not that game-breaking at all.

