### PR TITLE
adds W4 , W5 to SMC attache

### DIFF
--- a/maps/torch/job/torch_jobs_boh.dm
+++ b/maps/torch/job/torch_jobs_boh.dm
@@ -78,6 +78,8 @@
 		/datum/mil_rank/marine_corps/e8_alt,
 		/datum/mil_rank/marine_corps/e9,
 		/datum/mil_rank/marine_corps/e9_alt,
+		/datum/mil_rank/marine_corps/w4,
+		/datum/mil_rank/marine_corps/w5,
 		/datum/mil_rank/marine_corps/o1,
 		/datum/mil_rank/marine_corps/o2,
 		/datum/mil_rank/marine_corps/o3


### PR DESCRIPTION
Gives one of the most higher ranks of Warrant Officer to SMC attache.
I discussed with purple, he says W4 and W5 makes sense to the SMC attache due to his position of the job.
Making the only Job that can be a General Warrant Officer and Major Warrant Officer on the entire Dagon.
Being one of the most senior WO and have several knowledge.


